### PR TITLE
[PAG-1317]: replace className with class in editorPreview

### DIFF
--- a/.github/workflows/ShaCheck.yml
+++ b/.github/workflows/ShaCheck.yml
@@ -21,3 +21,5 @@ jobs:
           submodules: false
       - name: "Ensure SHA pinned actions"
         uses: zgosalvez/github-actions-ensure-sha-pinned-actions@0b552a197e44b819629237e065d781f5ca691460 # v1.1.1
+        with:
+          token: ${{ secrets.GH_PAT }}

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We removed `cypress` dependencies from the pluggable-widgets-tools and the script `test:e2e`. In case if you want to continue using Cypress, please install the dependencies manually.
 
+### Deprecated
+
+-   We've deprecated the `className` preview property. From now on, you have to use `class` property instead.
+
 ## [9.17.0] - 2022-09-02
 
 ### Added

--- a/packages/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/pluggable-widgets-tools/bin/mx-scripts.js
@@ -33,7 +33,7 @@ for (const subCommand of realCommand.split(/&&/g)) {
 
 function getRealCommand(cmd, toolsRoot) {
     const eslintCommand = "eslint --config .eslintrc.js --ext .jsx,.js,.ts,.tsx src";
-    const prettierConfigRootPath = join(__dirname, "../../../../prettier.config.js");
+    const prettierConfigRootPath = join(__dirname, "../../../prettier.config.js");
     const prettierConfigPath = existsSync(prettierConfigRootPath) ? prettierConfigRootPath : "prettier.config.js";
     const prettierCommand = `prettier --config "${prettierConfigPath}" "{src,typings,tests}/**/*.{js,jsx,ts,tsx,scss}"`;
     const rollupCommandWeb = `rollup --config "${join(toolsRoot, "configs/rollup.config.js")}"`;

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -27587,7 +27587,7 @@
       "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
       "dev": true,
       "requires": {
-        "colors": "1.0.3"
+        "colors": "1.4.0"
       }
     },
     "cli-width": {
@@ -32359,7 +32359,7 @@
         "@babel/preset-typescript": "^7.1.0",
         "@babel/register": "^7.0.0",
         "babel-core": "^7.0.0-bridge.0",
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "flow-parser": "0.*",
         "graceful-fs": "^4.2.4",
         "micromatch": "^3.1.10",

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -19,7 +19,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -17,7 +17,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -44,7 +44,11 @@ export interface MyWidgetProps<Style> {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
@@ -112,7 +116,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -20,7 +20,11 @@ export interface MyWidgetContainerProps {
 }
 
 export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -12,7 +12,11 @@ export function generatePreviewTypes(
     results.push(`export interface ${widgetName}PreviewProps {${
         !isLabeled
             ? `
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
     className: string;
+    class: string;
     style: string;
     styleObject?: CSSProperties;`
             : ""


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

_This is a recreation of https://github.com/mendix/widgets-resources/pull/1593 from the old repository._

For the sake of consistency between the Pluggable Widget API and the client, we have replaced the className preview property with class.

## Relevant changes

- Preview types generator

## What should be covered while testing?

- Verify whether the preview type generator uses the right property name.
