### PR TITLE
[WTF-1176]: return type depending on another property

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
--   We added support for expression returnType to refer to another property and generate its types
+-   We added support to the typings generator for the `assignableTo` return type of an [expression property](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#expression), introduced in Mendix 9.20. This feature allows the expected return type of the expression to be derived from an attribute property.
 
 ## [9.18.0] - 2022-10-27
 

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We updated the @author in the typings generator from `Mendix UI Content Team` to `Mendix Widgets Framework Team`.
 
+### Added
+
+-   We added support for expression returnType to refer to another property and generate its types
+
 ## [9.18.0] - 2022-10-27
 
 ### Removed

--- a/packages/pluggable-widgets-tools/bin/mx-scripts.js
+++ b/packages/pluggable-widgets-tools/bin/mx-scripts.js
@@ -93,7 +93,7 @@ function getRealCommand(cmd, toolsRoot) {
 }
 
 function findNodeModulesBin() {
-    let parentDir = join(__dirname, "../..");
+    let parentDir = join(__dirname, "..");
     while (parse(parentDir).root !== parentDir) {
         const candidate = join(parentDir, "node_modules/.bin");
         if (existsSync(candidate)) {

--- a/packages/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
@@ -81,7 +81,8 @@ export interface AssociationTypes {
 
 export interface ReturnType {
     $: {
-        type: string;
+        type?: string;
+        assignableTo?: string;
     };
 }
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -25,6 +25,8 @@ import { attributeLinkedActionInput, attributeNestedLinkedActionInput } from "./
 import { attributeLinkedActionOutput, attributeNestedLinkedActionOutput } from "./outputs/atribute-linked-action";
 import { associationInput, associationInputNative } from "./inputs/association";
 import { associationNativeOutput, associationWebOutput } from "./outputs/association";
+import { expressionInput, expressionInputNative } from "./inputs/expression";
+import { expressionWebOutput, expressionNativeOutput } from "./outputs/expression";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -145,6 +147,16 @@ describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native using linked association", () => {
         const newContent = generateNativeTypesFor(listAssociationNativeInput);
         expect(newContent).toBe(listAssociationNativeOutput);
+    });
+
+    it("Generates a parsed typing from XML for web using expression", () => {
+        const newContent = generateFullTypesFor(expressionInput);
+        expect(newContent).toBe(expressionWebOutput);
+    });
+
+    it("Generates a parsed typing from XML for native using expression", () => {
+        const newContent = generateNativeTypesFor(expressionInputNative);
+        expect(newContent).toBe(expressionNativeOutput);
     });
 });
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/expression.ts
@@ -1,0 +1,85 @@
+export const expressionInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="myDataSource" type="datasource" isList="true">
+                <caption>data source</caption>
+                <description />
+            </property>
+            <property key="expressionReturnTypeType" type="expression" required="true">
+                <caption>Expression returnType type</caption>
+                <description />
+                <returnType type="String" />
+            </property>
+            <property key="expressionReturnTypeTypeDataSource" type="expression" required="true" dataSource="myDataSource">
+                <caption>Expression returnType type with data source</caption>
+                <description />
+                <returnType type="String" />
+            </property>
+            <property key="expressionReturnTypeAssignableTo" type="expression" required="true">
+                <caption>Expression returnType assignableTo</caption>
+                <description />
+                <returnType assignableTo="myAttribute" />
+            </property>
+            <property key="expressionReturnTypeAssignableToDataSource" type="expression" required="true" dataSource="myDataSource">
+                <caption>Expression returnType assignableTo with data source</caption>
+                <description />
+                <returnType assignableTo="myAttribute" />
+            </property>
+            <property key="myAttribute" type="attribute">
+                <caption>My attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="Enum" />
+                    <attributeType name="Decimal" />
+                    <attributeType name="Boolean" />
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;
+
+export const expressionInputNative = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="myDataSource" type="datasource" isList="true">
+                <caption>data source</caption>
+                <description />
+            </property>
+            <property key="expressionReturnTypeType" type="expression" required="true">
+                <caption>Expression returnType type</caption>
+                <description />
+                <returnType type="String" />
+            </property>
+            <property key="expressionReturnTypeTypeDataSource" type="expression" required="true" dataSource="myDataSource">
+                <caption>Expression returnType type with data source</caption>
+                <description />
+                <returnType type="String" />
+            </property>
+            <property key="expressionReturnTypeAssignableTo" type="expression" required="true">
+                <caption>Expression returnType assignableTo</caption>
+                <description />
+                <returnType assignableTo="myAttribute" />
+            </property>
+            <property key="expressionReturnTypeAssignableToDataSource" type="expression" required="true" dataSource="myDataSource">
+                <caption>Expression returnType assignableTo with data source</caption>
+                <description />
+                <returnType assignableTo="myAttribute" />
+            </property>
+            <property key="myAttribute" type="attribute">
+                <caption>My attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="Enum" />
+                    <attributeType name="Decimal" />
+                    <attributeType name="Boolean" />
+                </attributeTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
@@ -1,0 +1,50 @@
+export const expressionWebOutput = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix Widgets Framework Team
+ */
+import { CSSProperties } from "react";
+import { DynamicValue, EditableValue, ListValue, ListExpressionValue } from "mendix";
+import { Big } from "big.js";
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex?: number;
+    myDataSource: ListValue;
+    expressionReturnTypeType: DynamicValue<string>;
+    expressionReturnTypeTypeDataSource: ListExpressionValue<string>;
+    expressionReturnTypeAssignableTo: DynamicValue<string | Big | boolean>;
+    expressionReturnTypeAssignableToDataSource: ListExpressionValue<string | Big | boolean>;
+    myAttribute: EditableValue<string | Big | boolean>;
+}
+
+export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
+    className: string;
+    class: string;
+    style: string;
+    styleObject?: CSSProperties;
+    readOnly: boolean;
+    myDataSource: {} | { type: string } | null;
+    expressionReturnTypeType: string;
+    expressionReturnTypeTypeDataSource: string;
+    expressionReturnTypeAssignableTo: string;
+    expressionReturnTypeAssignableToDataSource: string;
+    myAttribute: string;
+}
+`;
+
+export const expressionNativeOutput = `export interface MyWidgetProps<Style> {
+    name: string;
+    style: Style[];
+    myDataSource: ListValue;
+    expressionReturnTypeType: DynamicValue<string>;
+    expressionReturnTypeTypeDataSource: ListExpressionValue<string>;
+    expressionReturnTypeAssignableTo: DynamicValue<string | Big | boolean>;
+    expressionReturnTypeAssignableToDataSource: ListExpressionValue<string | Big | boolean>;
+    myAttribute: EditableValue<string | Big | boolean>;
+}`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -218,21 +218,21 @@ export function toExpressionClientType(
         );
     }
 
-    if (resolvedProperty.$.type != "attribute") {
+    if (resolvedProperty.$.type !== "attribute") {
         throw new Error(
             `[XML] Invalid return type for expression property: assignableTo property '${assignableTo}' must be of type Attribute.`
         );
     }
 
-    const allowedTypes = ["Boolean", "DateTime", "Enum", "Integer", "Long", "String", "Decimal"];
-
-    if (!resolvedProperty.attributeTypes?.length || !resolvedProperty.attributeTypes[0]) {
+    const { attributeTypes } = resolvedProperty;
+    if (!attributeTypes?.[0]?.attributeType) {
         throw new Error(
             `[XML] Invalid return type for expression property: assignableTo property '${assignableTo}' must have attribute types.`
         );
     }
 
-    const types = resolvedProperty.attributeTypes
+    const allowedTypes = ["Boolean", "DateTime", "Enum", "Integer", "Long", "String", "Decimal"];
+    const types = attributeTypes
         .map(ats => ats.attributeType)
         .reduce((a, i) => a.concat(i), [])
         .map(at => at.$.name);

--- a/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -1,5 +1,5 @@
-import { Property, SystemProperty } from "./WidgetXml";
-import { capitalizeFirstLetter, extractProperties } from "./helpers";
+import { Property, SystemProperty, ReturnType } from "./WidgetXml";
+import { capitalizeFirstLetter, commasAnd, extractProperties } from "./helpers";
 
 export function generateClientTypes(
     widgetName: string,
@@ -138,7 +138,7 @@ function toClientPropType(
             if (!prop.returnType || prop.returnType.length === 0) {
                 throw new Error("[XML] Expression property requires returnType element");
             }
-            const type = toAttributeClientType(prop.returnType[0].$.type);
+            const type = toExpressionClientType(prop.returnType[0], resolveProp);
             return prop.$.dataSource ? `ListExpressionValue<${type}>` : `DynamicValue<${type}>`;
         case "enumeration":
             const typeName = capitalizeFirstLetter(prop.$.key) + "Enum";
@@ -193,6 +193,62 @@ export function toAttributeClientType(xmlType: string): string {
         default:
             return "any";
     }
+}
+
+export function toExpressionClientType(
+    returnTypeProp: ReturnType,
+    resolveProp: (key: string) => Property | undefined
+): string {
+    const { type, assignableTo } = returnTypeProp.$ ?? {};
+
+    if ((type && assignableTo) || (!type && !assignableTo)) {
+        throw new Error(
+            "[XML] Invalid return type for expression property: either type or assignableTo must be specified."
+        );
+    }
+
+    if (type) {
+        return toAttributeClientType(type);
+    }
+
+    const resolvedProperty = resolveProp(assignableTo!);
+    if (!resolvedProperty) {
+        throw new Error(
+            `[XML] Invalid return type for expression property: invalid property path '${assignableTo}' in assignableTo attribute.`
+        );
+    }
+
+    if (resolvedProperty.$.type != "attribute") {
+        throw new Error(
+            `[XML] Invalid return type for expression property: assignableTo property '${assignableTo}' must be of type Attribute.`
+        );
+    }
+
+    const allowedTypes = ["Boolean", "DateTime", "Enum", "Integer", "Long", "String", "Decimal"];
+
+    if (!resolvedProperty.attributeTypes?.length || !resolvedProperty.attributeTypes[0]) {
+        throw new Error(
+            `[XML] Invalid return type for expression property: assignableTo property '${assignableTo}' must have attribute types.`
+        );
+    }
+
+    const types = resolvedProperty.attributeTypes
+        .map(ats => ats.attributeType)
+        .reduce((a, i) => a.concat(i), [])
+        .map(at => at.$.name);
+
+    const unsupportedTypes = types.filter(t => !allowedTypes.includes(t));
+    if (unsupportedTypes.length !== 0) {
+        throw new Error(
+            `[XML] Invalid return type for expression property: assignableTo property '${assignableTo}' has unsupported attribute type ${commasAnd(
+                unsupportedTypes
+            )}.`
+        );
+    }
+
+    const clientTypes = types.map(at => toAttributeClientType(at));
+    const uniqueTypes = Array.from(new Set(clientTypes));
+    return uniqueTypes.join(" | ");
 }
 
 export function toAssociationOutputType(xmlType: string, linkedToDataSource: boolean) {

--- a/packages/pluggable-widgets-tools/src/typings-generator/helpers.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/helpers.ts
@@ -17,3 +17,7 @@ function extractProps<P>(props: Properties, extractor: (props: Properties) => P[
 export function capitalizeFirstLetter(text: string): string {
     return text.charAt(0).toUpperCase() + text.slice(1);
 }
+
+export function commasAnd(arr: string[]) {
+    return arr.slice(0, -1).join(", ") + (arr.length > 1 ? " and " : "") + arr[arr.length - 1];
+}


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ❌

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Add support for expression return type to refer to another property and generate its types.

## Relevant changes

- Update case 'expression' from `toClientPropType` fn to generate types based on the existence of the attribute `assignableTo` on the returnType property. 