### PR TITLE
Fix the commit message for changelog updates when releasing a package

### DIFF
--- a/scripts/release/createRelease.ts
+++ b/scripts/release/createRelease.ts
@@ -113,7 +113,7 @@ async function updateChangelogsAndCreatePR(
     console.log(`Committing CHANGELOG.md to '${releaseBranchName}' and pushing to remote...`);
     await execShellCommand([
         `git add ${changelog.changelogPath}`,
-        `git commit -m "chore(${packageInfo.packageName}): update changelog"`,
+        `git commit -m "Update changelog for ${packageInfo.packageName}"`,
         `git push ${remoteName} ${releaseBranchName}`
     ]);
 


### PR DESCRIPTION
The commit message for changelog updates in the release process was still using the "semantic" message format that was retired during the repo split.