### PR TITLE
Update babel-jest config to prevent noisy warnings

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 -   We updated the @author in the typings generator from `Mendix UI Content Team` to `Mendix Widgets Framework Team`.
+-   We updated babel-jest configuration to prevent warnings during unit test execution.
 
 ### Added
 

--- a/packages/pluggable-widgets-tools/test-config/transform.js
+++ b/packages/pluggable-widgets-tools/test-config/transform.js
@@ -2,6 +2,7 @@ module.exports = require("babel-jest").createTransformer({
     presets: ["@babel/preset-env", "@babel/preset-react"],
     plugins: [
         ["@babel/plugin-proposal-class-properties", { loose: true }],
+        ["@babel/plugin-proposal-private-methods", { loose: true }],
         ["@babel/plugin-transform-react-jsx", { pragma: "createElement" }]
     ]
 });


### PR DESCRIPTION
Right now during unit test run babel generate lot of warnings, this config update should prevent them

```
column-chart-web:test: Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
column-chart-web:test: The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
column-chart-web:test: 	["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
column-chart-web:test: to the "plugins" section of your Babel config.
```

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (describe)

## What is the purpose of this PR?

- Update `babel` config
