### PR TITLE
[MOO-844]: Add a new option to rollup plugin

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+-   We added a new option to rollup plugin to exclude dependencies from the generated dependencies list file.
+
 -   We added support to the typings generator for the `assignableTo` return type of an [expression property](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#expression), introduced in Mendix 9.20. This feature allows the expected return type of the expression to be derived from an attribute property.
 
 ## [9.18.0] - 2022-10-27

--- a/packages/pluggable-widgets-tools/configs/rollup.config.native.js
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.native.js
@@ -81,7 +81,8 @@ export default async args => {
                                               template: licenseCustomTemplate
                                           }
                                       ]
-                                  }
+                                  },
+                                  excludeDependencies: ["@mendix/pluggable-widgets-tools"]
                               }
                           }
                         : null)


### PR DESCRIPTION
## Checklist

-   Contains breaking changes ❌
-   Did you update version and changelog? ✅

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (describe)

## What is the purpose of this PR?

When a new widget is created, the size of the dependencies file is quite large (more than 1MB). Most dependencies are added because of a peer dependency of `pluggable-widget-tools` in `piw-native-utils-internal`. To reduce the generated dependencies file size, provide a new option to exclude the `pluggable-widget-tools` dependency from the dependencies file.

## Relevant changes

Provided a new option to rollup plugin to exclude dependencies from the generated dependencies list file.

## What should be covered while testing?

When a widget is created using the release script, it should generate a dependencies list file that excludes the dependencies given in the option.
