### PR TITLE
[PAG-2016] Add the DataSource caption property

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 ### Added
 
--   We add the new data source caption to the typings generator.
+-   We added support to the typings generator for the data source caption (`{caption: string}`), introduced in version 9.24.0. This feature will give widget developers the ability to display the same caption for a data source, that Mendix uses in the Page Explorer, within a widget preview.
 
 ### Changed
 

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+-   We add the new data source caption to the typings generator.
 
 ### Changed
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -30,7 +30,7 @@ export interface MyWidgetPreviewProps {
     reference: string;
     referenceSet: string;
     referenceOrSet: string;
-    optionsSource: {} | { type: string } | null;
+    optionsSource: {} | { caption: string } | { type: string } | null;
     displayValue: string;
     referenceOnChange: {} | null;
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -52,8 +52,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    contentSource: {} | { type: string } | null;
-    optionalSource: {} | { type: string } | null;
+    contentSource: {} | { caption: string } | { type: string } | null;
+    optionalSource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ caption?: string }> };
     markerDataAttribute: string;
     actionAttribute: {} | null;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
@@ -29,7 +29,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    myDataSource: {} | { type: string } | null;
+    myDataSource: {} | { caption: string } | { type: string } | null;
     expressionReturnTypeType: string;
     expressionReturnTypeTypeDataSource: string;
     expressionReturnTypeAssignableTo: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -28,11 +28,11 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    dataSource: {} | { type: string } | null;
+    dataSource: {} | { caption: string } | { type: string } | null;
     reference: string;
     referenceSet: string;
     referenceOrSet: string;
-    optionsSource: {} | { type: string } | null;
+    optionsSource: {} | { caption: string } | { type: string } | null;
     displayValue: string;
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
@@ -36,8 +36,8 @@ export interface MyWidgetPreviewProps {
     optionalSelectionAll: "None" | "Single" | "Multi";
     optionalSelectionSingleMulti: "Single" | "Multi" | "None";
     optionalSelectionMulti: "Multi" | "None";
-    optionalDataSource: {} | { type: string } | null;
-    requiredDataSource: {} | { type: string } | null;
+    optionalDataSource: {} | { caption: string } | { type: string } | null;
+    requiredDataSource: {} | { caption: string } | { type: string } | null;
     onSelectionAllChange: {} | null;
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -67,7 +67,7 @@ function toPreviewPropType(
             return "string";
         case "datasource":
             // { type: string } is included here due to an incorrect API output before 9.2 (PAG-1400)
-            return "{} | { type: string } | null";
+            return "{} | { caption: string } | { type: string } | null";
         case "attribute":
         case "association":
         case "expression":


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

This PR adds a caption field to the DataSource so that custom widgets have access to DataSource caption as is used in the Page Explorer when generating previews for the page editor.
This feature will be added in the 9.24 version.

## Relevant changes

Updated the typings generator for GetPreview

## What should be covered while testing?

Widgets should be able to understand the DataSource caption when generating a preview for the page editor
