### PR TITLE
[WTF-1370] Add support for selection property (beta) to the typings generator

### DIFF
--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.20.0",
+  "version": "9.23.0",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"

--- a/packages/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
@@ -41,7 +41,8 @@ export interface Property {
             | "expression"
             | "enumeration"
             | "object"
-            | "widgets";
+            | "widgets"
+            | "selection";
         isList?: string;
         defaultValue?: string;
         required?: string;
@@ -57,6 +58,7 @@ export interface Property {
     returnType?: ReturnType[];
     properties?: Properties[];
     enumerationValues?: Enumeration[];
+    selectionTypes?: SelectionTypes[];
 }
 
 export interface AttributeType {
@@ -107,5 +109,15 @@ export interface Enumeration {
 export interface EnumerationValue {
     $: {
         key: string;
+    };
+}
+
+export interface SelectionTypes {
+    selectionType: SelectionType[];
+}
+
+export interface SelectionType {
+    $: {
+        name: string;
     };
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -27,6 +27,8 @@ import { associationInput, associationInputNative } from "./inputs/association";
 import { associationNativeOutput, associationWebOutput } from "./outputs/association";
 import { expressionInput, expressionInputNative } from "./inputs/expression";
 import { expressionWebOutput, expressionNativeOutput } from "./outputs/expression";
+import { selectionInput, selectionInputNative } from "./inputs/selection";
+import { selectionNativeOutput, selectionWebOutput } from "./outputs/selection";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -157,6 +159,16 @@ describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native using expression", () => {
         const newContent = generateNativeTypesFor(expressionInputNative);
         expect(newContent).toBe(expressionNativeOutput);
+    });
+
+    it("Generates a parsed typing from XML for web using selection", () => {
+        const newContent = generateFullTypesFor(selectionInput);
+        expect(newContent).toBe(selectionWebOutput);
+    });
+
+    it("Generates a parsed typing from XML for native using selection", () => {
+        const newContent = generateNativeTypesFor(selectionInputNative);
+        expect(newContent).toBe(selectionNativeOutput);
     });
 });
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/selection.ts
@@ -1,0 +1,131 @@
+export const selectionInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="selectionAll" type="selection" dataSource="requiredDataSource">
+                <caption>Selection (all types)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="None"/>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="selectionSingleMulti" type="selection" dataSource="requiredDataSource">
+                <caption>Selection (single or multi)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="selectionMulti" type="selection" dataSource="requiredDataSource">
+                <caption>Selection (multi only)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="optionalSelectionAll" type="selection" dataSource="optionalDataSource">
+                <caption>Optional selection (all)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="None"/>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="optionalSelectionSingleMulti" type="selection" dataSource="optionalDataSource">
+                <caption>Optional selection (single or multi)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="optionalSelectionMulti" type="selection" dataSource="optionalDataSource">
+                <caption>Optional selection (multi only)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+             <property key="optionalDataSource" type="datasource" isList="true" required="false">
+                <caption>Optional data source</caption>
+                <description />
+            </property>
+             <property key="requiredDataSource" type="datasource" isList="true">
+                <caption>Optional data source</caption>
+                <description />
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;
+
+export const selectionInputNative = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true" supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="selectionAll" type="selection" dataSource="requiredDataSource">
+                <caption>Selection (all types)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="None"/>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="selectionSingleMulti" type="selection" dataSource="requiredDataSource">
+                <caption>Selection (single or multi)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="selectionMulti" type="selection" dataSource="requiredDataSource">
+                <caption>Selection (multi only)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="optionalSelectionAll" type="selection" dataSource="optionalDataSource">
+                <caption>Optional selection (all)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="None"/>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="optionalSelectionSingleMulti" type="selection" dataSource="optionalDataSource">
+                <caption>Optional selection (single or multi)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Single"/>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+            <property key="optionalSelectionMulti" type="selection" dataSource="optionalDataSource">
+                <caption>Optional selection (multi only)</caption>
+                <description/>
+                <selectionTypes>
+                    <selectionType name="Multi"/>
+                </selectionTypes>
+            </property>
+             <property key="optionalDataSource" type="datasource" isList="true" required="false">
+                <caption>Optional data source</caption>
+                <description />
+            </property>
+             <property key="requiredDataSource" type="datasource" isList="true">
+                <caption>Optional data source</caption>
+                <description />
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
@@ -1,0 +1,55 @@
+export const selectionWebOutput = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix Widgets Framework Team
+ */
+import { CSSProperties } from "react";
+import { ListValue, SelectionSingleValue, SelectionMultiValue } from "mendix";
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex?: number;
+    selectionAll?: SelectionSingleValue | SelectionMultiValue;
+    selectionSingleMulti: SelectionSingleValue | SelectionMultiValue;
+    selectionMulti: SelectionMultiValue;
+    optionalSelectionAll?: SelectionSingleValue | SelectionMultiValue;
+    optionalSelectionSingleMulti?: SelectionSingleValue | SelectionMultiValue;
+    optionalSelectionMulti?: SelectionMultiValue;
+    optionalDataSource?: ListValue;
+    requiredDataSource: ListValue;
+}
+
+export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
+    className: string;
+    class: string;
+    style: string;
+    styleObject?: CSSProperties;
+    readOnly: boolean;
+    selectionAll: "None" | "Single" | "Multi";
+    selectionSingleMulti: "Single" | "Multi";
+    selectionMulti: "Multi";
+    optionalSelectionAll: "None" | "Single" | "Multi";
+    optionalSelectionSingleMulti: "Single" | "Multi" | "None";
+    optionalSelectionMulti: "Multi" | "None";
+    optionalDataSource: {} | { type: string } | null;
+    requiredDataSource: {} | { type: string } | null;
+}
+`;
+
+export const selectionNativeOutput = `export interface MyWidgetProps<Style> {
+    name: string;
+    style: Style[];
+    selectionAll?: SelectionSingleValue | SelectionMultiValue;
+    selectionSingleMulti: SelectionSingleValue | SelectionMultiValue;
+    selectionMulti: SelectionMultiValue;
+    optionalSelectionAll?: SelectionSingleValue | SelectionMultiValue;
+    optionalSelectionSingleMulti?: SelectionSingleValue | SelectionMultiValue;
+    optionalSelectionMulti?: SelectionMultiValue;
+    optionalDataSource?: ListValue;
+    requiredDataSource: ListValue;
+}`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -19,6 +19,8 @@ const mxExports = [
     "ListWidgetValue",
     "ReferenceValue",
     "ReferenceSetValue",
+    "SelectionSingleValue",
+    "SelectionMultiValue",
     "WebIcon",
     "WebImage"
 ];


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅❌
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Add support to the typings generator for the new `selection` property, which is added as a beta feature in Mendix 9.23. Since the feature is still in beta, we are omitting it from the changelog for now.

## Relevant changes

Depending on the configuration of the `selection` property, the typings generator will now emit:
- A client prop of (union) type `SelectionSingleValue` and/or `SelectionMultiValue`. Selection type `None` and/or a linked data source with `required="false"` results in an optional prop.
- A preview prop of (union) type `"None"`, `"Single"` and/or `"Multi"`. A linked data source with `required="false"` will cause `"None"` to be included in the type.

Unit tests have been added to check various combinations of the above.