### PR TITLE
[WTF-1432]: Missing dist folder in pwt 9.23.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "install:pwt": "cd ./packages/pluggable-widgets-tools && npm install",
     "postinstall": "npm run install:gw && npm run install:pwt",
     "reinstall": "shx rm -rf ./node_modules \"./packages/{generator-widget,pluggable-widgets-tools}/node_modules\" && npm install",
-    "test:pwt:commands": "npm run build --prefix ./packages/pluggable-widgets-tools && node tests/commands.js",
+    "test:pwt:commands": "node tests/commands.js",
     "prettier": "prettier --config \"./prettier.config.js\" --write \"**/*.{js,jsx,ts,tsx,scss,html,xml,yml,yaml}\"",
     "lint:scripts": "eslint --fix --config .eslintrc.js --ext .jsx,.js,.ts,.tsx scripts",
     "release:pwt": "ts-node --project ./scripts/tsconfig.json ./scripts/release/createRelease.ts pwt",

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue that prevented pluggable-widgets-tools commands to execute on 9.23.0.
+
 ## [9.23.0] - 2023-03-01
 
 ### Changed

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.23.0",
+  "version": "9.23.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "9.23.0",
+      "version": "9.23.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.23.0",
+  "version": "9.23.1",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"
@@ -11,7 +11,7 @@
     "pluggable-widgets-tools": "bin/mx-scripts.js"
   },
   "scripts": {
-    "build": "shx rm -rf dist && tsc",
+    "prepare": "shx rm -rf dist && tsc",
     "test": "jest"
   },
   "files": [


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Did you update version and changelog? ✅
- 
## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Fix the missing dist folder introduced on the pluggable-widgets-tools 9.23.0 release.

## Relevant changes

Replace the build script by prepare in the pluggable-widgets-tools.

The prepare script is necessary to trigger a build when installing the pluggable-widgets-tools.

## What should be covered while testing?

Make sure that the dist folder is generated after a npm install is called in the root folder or in the `packages/pluggable-widgets-tools` folder.
