### PR TITLE
[WTF-1433]: Change jest testEnvironment from node to jsdom on jest.native.config and jest.config.js

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue with jest configuration which was causing `pluggable-widgets-tools test:unit`, `pluggable-widgets-tools test:unit:web` and `pluggable-widgets-tools test:unit:native` to fail incorrectly.
+
 ## [9.23.1] - 2023-03-03
 
 ### Fixed

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.23.1",
+  "version": "9.23.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "9.23.1",
+      "version": "9.23.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -7215,6 +7215,15 @@
       },
       "engines": {
         "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/cli-table/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/cli-width": {
@@ -27437,7 +27446,15 @@
       "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
       "dev": true,
       "requires": {
-        "colors": "1.4.0"
+        "colors": "1.0.3"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+          "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+          "dev": true
+        }
       }
     },
     "cli-width": {
@@ -32209,7 +32226,7 @@
         "@babel/preset-typescript": "^7.1.0",
         "@babel/register": "^7.0.0",
         "babel-core": "^7.0.0-bridge.0",
-        "colors": "1.4.0",
+        "colors": "^1.1.2",
         "flow-parser": "0.*",
         "graceful-fs": "^4.2.4",
         "micromatch": "^3.1.10",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.23.1",
+  "version": "9.23.2",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"

--- a/packages/pluggable-widgets-tools/test-config/jest.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.config.js
@@ -26,5 +26,5 @@ module.exports = {
     },
     collectCoverage: !process.env.CI,
     coverageDirectory: "<rootDir>/../dist/coverage",
-    testEnvironment: "node"
+    testEnvironment: "jsdom"
 };

--- a/packages/pluggable-widgets-tools/test-config/jest.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.config.js
@@ -5,17 +5,17 @@ const projectDir = process.cwd();
 module.exports = {
     clearMocks: true,
     rootDir: join(projectDir, "src"),
-    globals: {
-        "ts-jest": {
-            isolatedModules: true,
-            tsconfig: { module: "commonjs" }
-        }
-    },
     setupFilesAfterEnv: [join(__dirname, "test-index.js")],
     snapshotSerializers: ["enzyme-to-json/serializer"],
     testMatch: ["<rootDir>/**/*.spec.{js,jsx,ts,tsx}"],
     transform: {
-        "\\.tsx?$": "ts-jest",
+        "\\.tsx?$": [
+            "ts-jest",
+            {
+                isolatedModules: true,
+                tsconfig: { module: "commonjs" }
+            }
+        ],
         "\\.jsx?$": join(__dirname, "transform.js"),
         "^.+\\.svg$": "jest-svg-transformer"
     },

--- a/packages/pluggable-widgets-tools/test-config/jest.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     rootDir: join(projectDir, "src"),
     globals: {
         "ts-jest": {
+            isolatedModules: true,
             tsconfig: { module: "commonjs" }
         }
     },

--- a/packages/pluggable-widgets-tools/test-config/jest.native.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.native.config.js
@@ -29,7 +29,7 @@ module.exports = {
     },
     collectCoverage: !process.env.CI,
     coverageDirectory: "<rootDir>/../dist/coverage",
-    testEnvironment: "node"
+    testEnvironment: "jsdom"
 };
 
 function hasDependency(name) {

--- a/packages/pluggable-widgets-tools/test-config/jest.native.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.native.config.js
@@ -8,6 +8,7 @@ module.exports = {
     rootDir: join(projectDir, "src"),
     globals: {
         "ts-jest": {
+            isolatedModules: true,
             tsconfig: { module: "commonjs" }
         }
     },

--- a/packages/pluggable-widgets-tools/test-config/jest.native.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.native.config.js
@@ -6,12 +6,6 @@ module.exports = {
     preset: "react-native",
     clearMocks: true,
     rootDir: join(projectDir, "src"),
-    globals: {
-        "ts-jest": {
-            isolatedModules: true,
-            tsconfig: { module: "commonjs" }
-        }
-    },
     setupFilesAfterEnv: [
         join(__dirname, "test-index-native.js"),
         ...(hasDependency("react-native-gesture-handler") ? ["react-native-gesture-handler/jestSetup.js"] : [])
@@ -20,7 +14,13 @@ module.exports = {
     testMatch: ["<rootDir>/**/*.spec.{js,jsx,ts,tsx}"],
     transformIgnorePatterns: ["node_modules/(?!.*react-native)(?!victory-)"],
     transform: {
-        "\\.tsx?$": "ts-jest",
+        "\\.tsx?$": [
+            "ts-jest",
+            {
+                isolatedModules: true,
+                tsconfig: { module: "commonjs" }
+            }
+        ],
         "\\.jsx?$": join(__dirname, "transform-native.js")
     },
     moduleNameMapper: {


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Did you update version and changelog? ✅

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Adjust Jest configuration to also work for widget tests.

## Relevant changes

Change Jest testEnvironment to jsdom.

## Extra comments (optional)

This MR also changes the ts-jest config to disable type checkings to improve CI performance.
It was previously taking +3 hours to finish running PWT Script Tests.
