### PR TITLE
[WTF-1531]: Bump the mendix typings from v9.24.2965 to v10.0.9976

### DIFF
--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We updated pluggable-widgets-tools dependency from ^9.24.0 to ^10.0.0.
+
 ## [9.24.2] - 2023-06-09
 
 ### Fixed

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0"
+    "@mendix/pluggable-widgets-tools": "^10.0.0"
   },
   "dependencies": {
 

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
@@ -22,7 +22,7 @@
     "release": "pluggable-widgets-tools release:native"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0"
+    "@mendix/pluggable-widgets-tools": "^10.0.0"
   },
   "dependencies": {
 

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^29.0.0"

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
@@ -22,7 +22,7 @@
     "release": "pluggable-widgets-tools release:native"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "@types/big.js": "^6.0.2"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
@@ -26,7 +26,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "cypress": "^10.10.0"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "cypress": "^10.10.0"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
@@ -27,7 +27,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0"
+    "@mendix/pluggable-widgets-tools": "^10.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.6"

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
@@ -25,7 +25,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0"
+    "@mendix/pluggable-widgets-tools": "^10.0.0"
   },
   "dependencies": {
     "classnames": "^2.2.6"

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
@@ -26,7 +26,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jasmine": "^3.6.9",

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jasmine": "^3.6.9",

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
@@ -27,7 +27,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^29.0.0",

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
@@ -25,7 +25,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0",
+    "@mendix/pluggable-widgets-tools": "^10.0.0",
     "@types/big.js": "^6.0.2"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },<% } %>
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.0.0"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasUnitTests) { %>,
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^29.0.0"<% } %><% } %>

--- a/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^9.24.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.0.0"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasUnitTests || hasE2eTests) { %>,
     "@types/enzyme": "^3.10.8"<% } %><% if (hasE2eTests) { %>,
     "@types/jasmine": "^3.6.9"<% } %><% if (hasUnitTests) { %>,

--- a/packages/generator-widget/package-lock.json
+++ b/packages/generator-widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "9.24.1",
+  "version": "10.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/generator-widget",
-      "version": "9.24.1",
+      "version": "10.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/packages/generator-widget/package.json
+++ b/packages/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "9.24.2",
+  "version": "10.0.0",
   "description": "Mendix Pluggable Widgets Generator",
   "engines": {
     "node": ">=16"

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We updated the Mendix package to version 10.0.9976.
+
+### Removed
+
+-   The ability to call a [linked property value](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-client-apis-list-values/#linked-values) directly as a function, which was deprecated in Mendix 9.0, has been removed from the widgets API.
+
 ## [9.24.1] - 2023-06-09
 
 ### Fixed

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.24.1",
+  "version": "10.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "9.24.1",
+      "version": "10.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -64,7 +64,7 @@
         "jest-junit": "^13.0.0",
         "jest-react-hooks-shallow": "^1.5.1",
         "make-dir": "^3.1.0",
-        "mendix": "^9.24.2965",
+        "mendix": "^10.0.9976",
         "metro-react-native-babel-preset": "^0.74.1",
         "mime": "^3.0.0",
         "node-fetch": "^2.6.1",
@@ -15052,9 +15052,9 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/mendix": {
-      "version": "9.24.2965",
-      "resolved": "https://registry.npmjs.org/mendix/-/mendix-9.24.2965.tgz",
-      "integrity": "sha512-YcWbfU/7KjvM9zSWmXrObYqFqKCG/HPnv6w8nTvOJSO3SLLogFIU0qeKd4BDHFxVAH7ouGWN874VAAgmBBIPNA==",
+      "version": "10.0.9976",
+      "resolved": "https://registry.npmjs.org/mendix/-/mendix-10.0.9976.tgz",
+      "integrity": "sha512-ZOIs3hhVY7QMPh3KEWjwpGram8QXpKfa81gzdkNdV9j/+3o19FBcsXL1sgl6U6Olqph/WalY1TqXWRRCZ7IbAw==",
       "dependencies": {
         "@types/big.js": "^6.0.0",
         "@types/react": "~18.0.21",
@@ -33563,9 +33563,9 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "mendix": {
-      "version": "9.24.2965",
-      "resolved": "https://registry.npmjs.org/mendix/-/mendix-9.24.2965.tgz",
-      "integrity": "sha512-YcWbfU/7KjvM9zSWmXrObYqFqKCG/HPnv6w8nTvOJSO3SLLogFIU0qeKd4BDHFxVAH7ouGWN874VAAgmBBIPNA==",
+      "version": "10.0.9976",
+      "resolved": "https://registry.npmjs.org/mendix/-/mendix-10.0.9976.tgz",
+      "integrity": "sha512-ZOIs3hhVY7QMPh3KEWjwpGram8QXpKfa81gzdkNdV9j/+3o19FBcsXL1sgl6U6Olqph/WalY1TqXWRRCZ7IbAw==",
       "requires": {
         "@types/big.js": "^6.0.0",
         "@types/react": "~18.0.21",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "9.24.1",
+  "version": "10.0.0",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"
@@ -80,7 +80,7 @@
     "jest-junit": "^13.0.0",
     "jest-react-hooks-shallow": "^1.5.1",
     "make-dir": "^3.1.0",
-    "mendix": "^9.24.2965",
+    "mendix": "^10.0.9976",
     "metro-react-native-babel-preset": "^0.74.1",
     "mime": "^3.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ✅ 
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣ ,🔟 

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

To update the Mendix typings from v9.24.2965 to v10.0.9976

## Relevant changes

In this PR we are bumping the Mendix package to v10.0.9976 in the pluggable-widgets-tools package and also bumping the generator-widget package.json templates to include the Mendix 10