### PR TITLE
[WTF-1602] Fix rollup windows exports must be in unix format

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed a bug in rollup-plugin-assets causing assets url on windows to not have the correct path separator (Ticket 194099).
+
 ### Changed
 
 -   We removed `watch` option from base config for typescript

--- a/packages/pluggable-widgets-tools/configs/rollup-plugin-assets.js
+++ b/packages/pluggable-widgets-tools/configs/rollup-plugin-assets.js
@@ -61,7 +61,7 @@ export default function url(options = {}) {
                         .replace(/\[dirname\]/g, relativeDir === "" ? "" : `${relativeDir}${sep}`)
                         .replace(/\[name\]/g, name);
                     // Windows fix - exports must be in unix format
-                    data = `${publicPath}${outputFileName.split(sep).join(posix.sep)}`;
+                    data = (publicPath + outputFileName).split(sep).join(posix.sep);
                     copies[id] = outputFileName;
                 } else {
                     const mimetype = mime.getType(id);


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣, 🔟

## This PR contains

-   [x] Bug fix

## What is the purpose of this PR?

To fix a bug in the rollup-plugin-assets.js causing assets url to not return in Unix format, which then breaks on Windows.
