### PR TITLE
[WTF-1735]: Fix PWT resolution/override versions

### DIFF
--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -105,6 +105,7 @@
     "sass": "^1.43.4",
     "semver": "^7.3.2",
     "shelljs": "^0.8.4",
+    "shx": "^0.3.3",
     "ts-jest": "^29.0.0",
     "ts-node": "^9.0.0",
     "typescript": "4.9.5",
@@ -115,7 +116,6 @@
     "@mendix/generator-widget": ">=8.9.0",
     "@types/xml2js": "^0.4.5",
     "async-mutex": "^0.2.4",
-    "shx": "^0.3.3",
     "tree-kill": "^1.2.2",
     "yeoman-test": "^6.2.0"
   },

--- a/packages/pluggable-widgets-tools/utils/migration.js
+++ b/packages/pluggable-widgets-tools/utils/migration.js
@@ -171,6 +171,9 @@ async function checkMigration() {
                     }
                     // Writes the new package keeping the current format
                     await writeJson(packageJsonPath, newPackageJson, { spaces: 2 });
+                    console.log("Deleting old dependencies...");
+                    execSync("shx rm -rf ./{node_modules,package-lock.json}", { cwd: process.cwd(), stdio: "inherit" });
+                    console.log("Done.");
                     execSync(`npm install`, { cwd: process.cwd(), stdio: "inherit" });
                 } catch (e) {
                     console.log(red("An error occurred while auto updating your dependencies"));

--- a/packages/pluggable-widgets-tools/utils/migration.js
+++ b/packages/pluggable-widgets-tools/utils/migration.js
@@ -45,13 +45,18 @@ const dependencies = [
     { name: "react-native-push-notification", version: "8.1.1", check: CheckType.MAJOR_MINOR },
     { name: "react-native-webview", version: "11.26.1", check: CheckType.MAJOR_MINOR }
 ];
+
+const reactVersion = "18.2.0";
+const reactDomVersion = "18.2.0";
+const reactNativeVersion = "0.70.7";
+
 const resolutionsOverrides = [
-    { name: "react", version: "18.2.0", check: CheckType.MAJOR_MINOR },
-    { name: "react-dom", version: "18.2.0", check: CheckType.MAJOR_MINOR },
-    { name: "react-native", version: "0.70.7", check: CheckType.MINOR },
-    { name: "@types/react", version: "18.0.0", check: CheckType.MAJOR },
-    { name: "@types/react-dom", version: "18.0.0", check: CheckType.MAJOR },
-    { name: "@types/react-native", version: "0.70.0", check: CheckType.MINOR }
+    { name: "react", version: reactVersion, check: CheckType.MAJOR_MINOR },
+    { name: "react-dom", version: reactDomVersion, check: CheckType.MAJOR_MINOR },
+    { name: "react-native", version: reactNativeVersion, check: CheckType.MINOR },
+    { name: "@types/react", version: reactVersion, check: CheckType.MAJOR },
+    { name: "@types/react-dom", version: reactDomVersion, check: CheckType.MAJOR },
+    { name: "@types/react-native", version: reactNativeVersion, check: CheckType.MINOR }
 ];
 
 function extractVersions(version) {

--- a/packages/pluggable-widgets-tools/utils/migration.js
+++ b/packages/pluggable-widgets-tools/utils/migration.js
@@ -46,17 +46,17 @@ const dependencies = [
     { name: "react-native-webview", version: "11.26.1", check: CheckType.MAJOR_MINOR }
 ];
 
-const reactVersion = "18.2.0";
-const reactDomVersion = "18.2.0";
-const reactNativeVersion = "0.70.7";
+const reactPackage = { version: "18.2.0", check: CheckType.MAJOR_MINOR };
+const reactDomPackage = { version: "18.2.0", check: CheckType.MAJOR_MINOR };
+const reactNativePackage = { version: "0.70.7", check: CheckType.MINOR };
 
 const resolutionsOverrides = [
-    { name: "react", version: reactVersion, check: CheckType.MAJOR_MINOR },
-    { name: "react-dom", version: reactDomVersion, check: CheckType.MAJOR_MINOR },
-    { name: "react-native", version: reactNativeVersion, check: CheckType.MINOR },
-    { name: "@types/react", version: reactVersion, check: CheckType.MAJOR },
-    { name: "@types/react-dom", version: reactDomVersion, check: CheckType.MAJOR },
-    { name: "@types/react-native", version: reactNativeVersion, check: CheckType.MINOR }
+    { name: "react", ...reactPackage },
+    { name: "react-dom", ...reactDomPackage },
+    { name: "react-native", ...reactNativePackage },
+    { name: "@types/react", ...reactPackage },
+    { name: "@types/react-dom", ...reactDomPackage },
+    { name: "@types/react-native", ...reactNativePackage }
 ];
 
 function extractVersions(version) {

--- a/packages/pluggable-widgets-tools/utils/migration.js
+++ b/packages/pluggable-widgets-tools/utils/migration.js
@@ -143,7 +143,8 @@ async function checkMigration() {
             outdatedResolutions.length > 0
         ) {
             const answer = await question(
-                "Your widget contains outdated dependencies that will not work with this version of Pluggable Widgets Tools, do you want to upgrade it automatically? [Y/n]: "
+                "Your widget contains outdated dependencies that will not work with this version of Pluggable Widgets Tools, do you want to upgrade it automatically?" +
+                "Note that this operation will delete your node_modules folder and package-lock.json files and re-create them. [Y/n]: "
             );
             if (answer === "y") {
                 try {


### PR DESCRIPTION
Fix the misaligned versions for `react`, `react-dom`, `react-native` packages and their corresponding `@types` packages during migration.

## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Compatible with:
-   Did you update version and changelog?  ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe)

## What is the purpose of this PR?

The migration script creates resolutions and overrides for three packages in an incorrect way. This PR fixes the issue by aligning the versions of those packages in the migration script.

## Relevant changes

Some hard coded values are adjusted and extracted into constants to be the same everywhere they are relavant.

## What should be covered while testing?

An example widget should be upgraded using the standard procedure. Another PR in docs repository is on the way to clearly state this standard procedure of upgrade.