### PR TITLE
[WTF-1757] Bump the mendix typings from v10.5.216275 to v10.7.26214

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We updated the Mendix package to version 10.7.26214.
+
 ## [10.5.1] - 2024-01-19
 
 ### Fixed

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.5.1",
+  "version": "10.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "10.5.1",
+      "version": "10.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -64,7 +64,7 @@
         "jest-junit": "^13.0.0",
         "jest-react-hooks-shallow": "^1.5.1",
         "make-dir": "^3.1.0",
-        "mendix": "^10.5.21627",
+        "mendix": "^10.7.26214",
         "metro-react-native-babel-preset": "^0.74.1",
         "mime": "^3.0.0",
         "node-fetch": "^2.6.1",
@@ -14464,12 +14464,12 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "node_modules/mendix": {
-      "version": "10.5.21627",
-      "resolved": "https://registry.npmjs.org/mendix/-/mendix-10.5.21627.tgz",
-      "integrity": "sha512-BBFKj6s1i7zinvBESxqKENB1uPcNcsAjXY9LlHqtfSEvLyvgzIP9/gfTB4js8HXtkdhAYd58kKL8s+p4fGs2Bg==",
+      "version": "10.7.26214",
+      "resolved": "https://registry.npmjs.org/mendix/-/mendix-10.7.26214.tgz",
+      "integrity": "sha512-W31AIew6noczo/CIkhK2Z2GX95p6Ply8RwV3xQwsaEeGoyMoFy64b3v9UJAPso51AYr27LfLuieh+lplUnGSIg==",
       "dependencies": {
         "@types/big.js": "^6.0.0",
-        "@types/react": "~18.0.21",
+        "@types/react": "~18.0.0",
         "@types/react-native": "~0.70.2"
       }
     },
@@ -32179,12 +32179,12 @@
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="
     },
     "mendix": {
-      "version": "10.5.21627",
-      "resolved": "https://registry.npmjs.org/mendix/-/mendix-10.5.21627.tgz",
-      "integrity": "sha512-BBFKj6s1i7zinvBESxqKENB1uPcNcsAjXY9LlHqtfSEvLyvgzIP9/gfTB4js8HXtkdhAYd58kKL8s+p4fGs2Bg==",
+      "version": "10.7.26214",
+      "resolved": "https://registry.npmjs.org/mendix/-/mendix-10.7.26214.tgz",
+      "integrity": "sha512-W31AIew6noczo/CIkhK2Z2GX95p6Ply8RwV3xQwsaEeGoyMoFy64b3v9UJAPso51AYr27LfLuieh+lplUnGSIg==",
       "requires": {
         "@types/big.js": "^6.0.0",
-        "@types/react": "~18.0.21",
+        "@types/react": "~18.0.0",
         "@types/react-native": "~0.70.2"
       }
     },

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.5.1",
+  "version": "10.7.0",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"
@@ -80,7 +80,7 @@
     "jest-junit": "^13.0.0",
     "jest-react-hooks-shallow": "^1.5.1",
     "make-dir": "^3.1.0",
-    "mendix": "^10.5.21627",
+    "mendix": "^10.7.26214",
     "metro-react-native-babel-preset": "^0.74.1",
     "mime": "^3.0.0",
     "node-fetch": "^2.6.1",


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌ 
-   Contains breaking changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣ ,🔟 

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

To update the Mendix typings from v10.5.216275 to v10.7.26214

## Relevant changes

In this PR we are bumping the Mendix package to  v10.7.26214 in the pluggable-widgets-tools package