### PR TITLE
[WTF-1780]: module level directive warnings should not cause bundling to fail

### DIFF
--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We updated pluggable-widgets-tools dependency from ^10.5.0 to ^10.7.1.
+
 ## [10.5.1] - 2024-01-31
 
 ### Changed

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0"
+    "@mendix/pluggable-widgets-tools": "^10.7.1"
   },
   "dependencies": {
 

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
@@ -22,7 +22,7 @@
     "release": "pluggable-widgets-tools release:native"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0"
+    "@mendix/pluggable-widgets-tools": "^10.7.1"
   },
   "dependencies": {
 

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^29.0.0"

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
@@ -22,7 +22,7 @@
     "release": "pluggable-widgets-tools release:native"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "@types/big.js": "^6.0.2"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
@@ -26,7 +26,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "cypress": "^10.10.0"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "cypress": "^10.10.0"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
@@ -27,7 +27,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0"
+    "@mendix/pluggable-widgets-tools": "^10.7.1"
   },
   "dependencies": {
     "classnames": "^2.2.6"

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
@@ -25,7 +25,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0"
+    "@mendix/pluggable-widgets-tools": "^10.7.1"
   },
   "dependencies": {
     "classnames": "^2.2.6"

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
@@ -26,7 +26,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jasmine": "^3.6.9",

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jasmine": "^3.6.9",

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
@@ -27,7 +27,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "@types/big.js": "^6.0.2",
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^29.0.0",

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
@@ -25,7 +25,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0",
+    "@mendix/pluggable-widgets-tools": "^10.7.1",
     "@types/big.js": "^6.0.2"
   },
   "dependencies": {

--- a/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },<% } %>
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.7.1"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasUnitTests) { %>,
     "@types/enzyme": "^3.10.8",
     "@types/jest": "^29.0.0"<% } %><% } %>

--- a/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^10.5.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.7.1"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasUnitTests || hasE2eTests) { %>,
     "@types/enzyme": "^3.10.8"<% } %><% if (hasE2eTests) { %>,
     "@types/jasmine": "^3.6.9"<% } %><% if (hasUnitTests) { %>,

--- a/packages/generator-widget/package-lock.json
+++ b/packages/generator-widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "10.5.1",
+  "version": "10.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/generator-widget",
-      "version": "10.5.1",
+      "version": "10.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/packages/generator-widget/package.json
+++ b/packages/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "10.5.1",
+  "version": "10.7.1",
   "description": "Mendix Pluggable Widgets Generator",
   "engines": {
     "node": ">=16"

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where rollup warnings about `use client` and `use server` were causing bundling failures.
+
 ## [10.7.0] - 2024-01-31
 
 ### Changed

--- a/packages/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.js
@@ -281,12 +281,15 @@ export default async args => {
     }
 
     function onwarn(warning, warn) {
+        // Module level directives is ignored by Rollup since it causes error when bundled.
+        // And to not pollute the terminal, the warning code "MODULE_LEVEL_DIRECTIVE"
+        // should be ignored and handled separetely from the safe warning list.
         if (warning.code === "MODULE_LEVEL_DIRECTIVE") return;
 
         // Many rollup warnings are indication of some critical issue, so we should treat them as errors,
         // except a short white-list which we know is safe _and_ not easily fixable.
         const safeWarnings = ["CIRCULAR_DEPENDENCY", "THIS_IS_UNDEFINED", "UNUSED_EXTERNAL_IMPORT"];
-        if (safeWarnings.includes(warning.code)) {
+        if (args.watch || safeWarnings.includes(warning.code)) {
             return warn(warning);
         }
 

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "10.7.0",
+      "version": "10.7.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣, 🔟
-   Did you update version and changelog? ✅

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [x] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

This PR fixes an issue with rollup treating "module directives" warning as an error which was causing bundling to fail.
_..._

## Relevant changes

- The warning `MODULE_LEVEL_DIRECTIVE` should return to not kill the bundle process and pollute the terminal since it should be a common warning from now on as more libraries implement react directives.
- The warning message style has been changed to use the standard `warn` function from Rollup since its output on the terminal is better formatted. Example below:

Before:

![image](https://github.com/mendix/widgets-tools/assets/6069943/1609acab-ebde-415e-a8ea-10f84229a8fb)

After:

![image](https://github.com/mendix/widgets-tools/assets/6069943/60e5c98b-f8c1-4500-a92d-aa52a6de3cfb)

## What should be covered while testing?

- That importing libraries like `ag-grid-react`, `antd` and `@mui/material` to your widget does not cause bundling to fail.

How to test?

- Navigate to `packages/pluggable-widgets-tools`
- Pack the library using `npm pack`
- Copy the path
- Navigate to your widget and install the zip file using `npm install {zip-file-absolute-path}`
- Make sure that you are importing a library that uses the new react directive `use client` or `use server`. Ex:  `ag-grid-react`, `antd` or `@mui/material
- Build the widget using `npm run build`

