### PR TITLE
[WC-2383] Force close rollup process hanging

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where the rollup process would sometimes hang and prevent the widget build/release script from completing.
+
 ### Changed
 
 -   We moved Pluggable Widgets Tools dependencies marked as external in rollup configuration files to devDependencies in the package.json.

--- a/packages/pluggable-widgets-tools/configs/rollup.config.js
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.js
@@ -186,7 +186,15 @@ export default async args => {
                     transpile: true,
                     babelConfig: { presets: [["@babel/preset-env", { targets: { ie: "11" } }]] },
                     external: commonExternalLibs
-                })
+                }),
+                {
+                    closeBundle() {
+                        if (!process.env.ROLLUP_WATCH) {
+                          setTimeout(() => process.exit(0));
+                        }
+                    },
+                    name: 'force-close'
+                }
             ],
             onwarn
         });


### PR DESCRIPTION
## Checklist

-   Contains unit tests  ❌
-   Contains breaking changes ❌
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Sometimes when running the pluggable widget tools script for release or build a widget, the rollup doesn’t finish the process. That happens in the editorConfig step.

## Relevant changes

To resolve that for now I have followed one suggestion from the rollup repository PR to force close the process because we’re still using rollup v3 in the pluggable widget tools. 

That was fixed in v4, it was created one new parameter to pass to rollup to force exit. If so, then this fix can be removed and starts to use the new parameter mentioned above.

https://github.com/rollup/rollup/issues/4213#issuecomment-1660979577

