### PR TITLE
[WTF-1855] Fix rollup hanging while bundling files with react directive and sourcemaps

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue where the rollup process would sometimes hang and prevent the widget build/release script from completing. 
+
 ## [10.7.2] - 2024-03-06
 
 ### Fixed

--- a/packages/pluggable-widgets-tools/configs/shared.js
+++ b/packages/pluggable-widgets-tools/configs/shared.js
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { existsSync, readdirSync, promises as fs } from "fs";
-import { join } from "path";
+import { join, relative } from "path";
 import { config } from "dotenv";
+import { red } from "ansi-colors";
 
 config({ path: join(process.cwd(), ".env") });
 
@@ -47,6 +48,32 @@ export const projectPath = [
     join(sourcePath, "tests/testProject")
 ].filter(path => path && existsSync(path))[0];
 
+export const onwarn = (args) => (warning, warn) => {
+  // Module level directives is ignored by Rollup since it causes error when bundled.
+  // And to not pollute the terminal, the warning code "MODULE_LEVEL_DIRECTIVE" and "SOURCEMAP_ERROR"
+  // should be ignored and handled separetely from the safe warning list.
+  if (warning.code === "MODULE_LEVEL_DIRECTIVE" || warning.code === "SOURCEMAP_ERROR") return;
+
+  // Many rollup warnings are indication of some critical issue, so we should treat them as errors,
+  // except a short white-list which we know is safe _and_ not easily fixable.
+  const safeWarnings = ["CIRCULAR_DEPENDENCY", "THIS_IS_UNDEFINED", "UNUSED_EXTERNAL_IMPORT"];
+  if (args.watch || safeWarnings.includes(warning.code)) {
+      return warn(warning);
+  }
+
+  const error =
+      (warning.plugin ? `(${warning.plugin} plugin) ` : "") +
+      (warning.loc
+          ? `${relative(sourcePath, warning.loc.file)} (${warning.loc.line}:${warning.loc.column}) `
+          : "") +
+      `Error: ${warning.message}` +
+      (warning.frame ? warning.frame : "");
+
+  console.error(red(error));
+  process.exit(1);
+}
+
 function escape(str) {
     return str.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
 }
+

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.7.2",
+  "version": "10.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "10.7.2",
+      "version": "10.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.12.3",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.7.2",
+  "version": "10.7.3",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣, 10
-   Did you update version and changelog? ✅

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

This PR fixes sourceMap warnings causing the bundling to fail.

## What should be covered while testing?

Build a widget that uses an external library that supports react directives.
Examples: `react-toastify`

The bundling process should not throw an error
