### PR TITLE
[WTF-1883]: Support reference sets for non-linked attribute property

### DIFF
--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -31,6 +31,14 @@ import { selectionInput, selectionInputNative } from "./inputs/selection";
 import { selectionNativeOutput, selectionWebOutput } from "./outputs/selection";
 import { listAttributeNativeInput, listAttributeWebInput } from "./inputs/list-attribute-refset";
 import { listAttributeNativeOutput, listAttributeWebOutput } from "./outputs/list-attribute-refset";
+import {
+    nonLinkedListAttributeNativeInput,
+    nonLinkedListAttributeWebInput
+} from "./inputs/non-linked-list-attribute-refset";
+import {
+    nonLinkedListAttributeNativeOutput,
+    nonLinkedListAttributeWebOutput
+} from "./outputs/non-linked-list-attribute-refset";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -181,6 +189,16 @@ describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native using ref sets in linked attribute", () => {
         const newContent = generateNativeTypesFor(listAttributeNativeInput);
         expect(newContent).toBe(listAttributeNativeOutput);
+    });
+
+    it("Generates a parsed typing from XML for web using ref sets in non-linked attribute", () => {
+        const newContent = generateFullTypesFor(nonLinkedListAttributeWebInput);
+        expect(newContent).toBe(nonLinkedListAttributeWebOutput);
+    });
+
+    it("Generates a parsed typing from XML for native using ref sets in non-linked attribute", () => {
+        const newContent = generateNativeTypesFor(nonLinkedListAttributeNativeInput);
+        expect(newContent).toBe(nonLinkedListAttributeNativeOutput);
     });
 });
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/non-linked-list-attribute-refset.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/non-linked-list-attribute-refset.ts
@@ -1,0 +1,95 @@
+export const nonLinkedListAttributeWebInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+             <property key="referenceDefault" type="attribute">
+                <caption>Reference</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+            <property key="reference" type="attribute">
+                <caption>Reference</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                </associationTypes>
+            </property>
+            <property key="referenceSet" type="attribute">
+                <caption>Reference Set</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+                <associationTypes>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+            <property key="referenceOrSet" type="attribute">
+                <caption>Reference or Set</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;
+
+export const nonLinkedListAttributeNativeInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true" supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+             <property key="referenceDefault" type="attribute">
+                <caption>Reference</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+            </property>
+            <property key="reference" type="attribute">
+                <caption>Reference</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                </associationTypes>
+            </property>
+            <property key="referenceSet" type="attribute">
+                <caption>Reference Set</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+                <associationTypes>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+            <property key="referenceOrSet" type="attribute">
+                <caption>Reference or Set</caption>
+                <description/>
+                <attributeTypes>
+                    <attributeType name="String" />
+                </attributeTypes>
+                <associationTypes>
+                    <associationType name="Reference"/>
+                    <associationType name="ReferenceSet"/>
+                </associationTypes>
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/non-linked-list-attribute-refset.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/non-linked-list-attribute-refset.ts
@@ -1,0 +1,43 @@
+export const nonLinkedListAttributeWebOutput = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix Widgets Framework Team
+ */
+import { CSSProperties } from "react";
+import { EditableValue, EditableListValue } from "mendix";
+
+export interface MyWidgetContainerProps {
+    name: string;
+    class: string;
+    style?: CSSProperties;
+    tabIndex?: number;
+    referenceDefault: EditableValue<string>;
+    reference: EditableValue<string>;
+    referenceSet: EditableListValue<string>;
+    referenceOrSet: EditableValue<string> | EditableListValue<string>;
+}
+
+export interface MyWidgetPreviewProps {
+    /**
+     * @deprecated Deprecated since version 9.18.0. Please use class property instead.
+     */
+    className: string;
+    class: string;
+    style: string;
+    styleObject?: CSSProperties;
+    readOnly: boolean;
+    referenceDefault: string;
+    reference: string;
+    referenceSet: string;
+    referenceOrSet: string;
+}
+`;
+
+export const nonLinkedListAttributeNativeOutput = `export interface MyWidgetProps<Style> {
+    name: string;
+    style: Style[];
+    referenceDefault: EditableValue<string>;
+    reference: EditableValue<string>;
+    referenceSet: EditableListValue<string>;
+    referenceOrSet: EditableValue<string> | EditableListValue<string>;
+}`;


### PR DESCRIPTION
‼️ ## NOTE: This PR is supposed to be merged after the 10.13 release with the new typings package.


Add unit tests for non-linked attribute property with reference sets.

## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ❌
-   Compatible with: MX 🔟
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (describe)

## What is the purpose of this PR?
This PR adds unit tests for typings generation in PWT the recently implemented reference sets with attribute property story.