### PR TITLE
[WTF-1922]: Fix react and @types/react package mismatch in PWT

### DIFF
--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+-   We added `@types/react` package and aligned its version with the `react` package to ^18.2.0 in resolutions and overrides for the Yeoman generator. 
+
 ## [10.7.2] - 2024-03-07
 
 ### Changed

--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
--   We added `@types/react` package and aligned its version with the `react` package to ^18.2.0 in resolutions and overrides for the Yeoman generator. 
+### Changed
+
+-   We updated the default overrides (and resolutions) for generated widgets to ensure consistent React types with `@mendix/pluggable-widgets-tools`. This fixes errors like "_Type Element is not assignable to type ReactElement_".
 
 ## [10.7.2] - 2024-03-07
 

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
@@ -33,11 +33,11 @@
 
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
@@ -28,11 +28,11 @@
 
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
@@ -36,11 +36,13 @@
 
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
@@ -29,11 +29,13 @@
 
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
@@ -33,11 +33,11 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
@@ -35,11 +35,11 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
@@ -33,11 +33,11 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
@@ -31,11 +31,11 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
@@ -36,11 +36,13 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
@@ -40,11 +40,13 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
@@ -37,11 +37,13 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
@@ -32,11 +32,13 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",
+    "@types/react": "^18.2.0",
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -36,11 +36,13 @@
 
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",<% } %>
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",<% } %>
     "react-native": "0.72.7"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -40,11 +40,13 @@
     "classnames": "^2.2.6"
   },
   "resolutions": {
-    "react": "18.2.0",
+    "react": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",<% } %>
     "react-native": "0.72.7"
   },
   "overrides": {
-    "react": "18.2.0",
+    "react": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",<% } %>
     "react-native": "0.72.7"
   }
 }

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -17038,7 +17038,7 @@
         "node": ">=16"
       },
       "peerDependencies": {
-        "react": "18.2.0"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-native/node_modules/@jest/types": {


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ❌
-   Compatible with: MX 🔟
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other (describe)

## What is the purpose of this PR?

The purpose of the changes is to fix the compilation error due to a version mismatch among the dependencies. 

## Relevant changes

The Yeoman Generator for scaffolding a pluggable widget has been adjusted to include `@types/react` package with `18.2.79`. Related unit tests are also adjusted in accordance with the changes.
