### PR TITLE
[PAG-2309] Add support for render modes on pluggable widgets

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Added
-- We added the renderMode parameter to the preview arguments. This flag will give developers the ability to customize the preview for different render modes namnely x-ray, structure and design.
+- We added the renderMode parameter to the preview arguments. This flag will give developers the ability to customize the preview for different render modes namely x-ray, structure and design.
 
 ### Changed
 

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this tool will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- We added the renderMode parameter to the preview arguments. This flag will give developers the ability to customize the preview for different render modes namnely x-ray, structure and design.
 
 ### Changed
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -27,6 +27,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     reference: string;
     referenceSet: string;
     referenceOrSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -27,9 +27,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     reference: string;
     referenceSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -27,7 +27,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     reference: string;
     referenceSet: string;
     referenceOrSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
@@ -14,6 +14,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     collapsed: string;
     onToggleCollapsed: {} | null;
 }
@@ -51,6 +52,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     onToggleCollapsed: {} | null;
     datasourceProperties: DatasourcePropertiesPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
@@ -14,9 +14,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     collapsed: string;
     onToggleCollapsed: {} | null;
@@ -55,9 +52,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     onToggleCollapsed: {} | null;
     datasourceProperties: DatasourcePropertiesPreviewType[];

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
@@ -14,7 +14,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     collapsed: string;
     onToggleCollapsed: {} | null;
 }
@@ -52,7 +55,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     onToggleCollapsed: {} | null;
     datasourceProperties: DatasourcePropertiesPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -25,6 +25,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     description: string;
     action: {} | null;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -25,7 +25,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     description: string;
     action: {} | null;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -25,9 +25,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     description: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -52,7 +52,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     contentSource: {} | { caption: string } | { type: string } | null;
     optionalSource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -52,6 +52,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     contentSource: {} | { caption: string } | { type: string } | null;
     optionalSource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -52,9 +52,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     contentSource: {} | { caption: string } | { type: string } | null;
     optionalSource: {} | { caption: string } | { type: string } | null;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
@@ -29,6 +29,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     myDataSource: {} | { caption: string } | { type: string } | null;
     expressionReturnTypeType: string;
     expressionReturnTypeTypeDataSource: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
@@ -29,9 +29,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     myDataSource: {} | { caption: string } | { type: string } | null;
     expressionReturnTypeType: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
@@ -29,7 +29,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     myDataSource: {} | { caption: string } | { type: string } | null;
     expressionReturnTypeType: string;
     expressionReturnTypeTypeDataSource: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -17,9 +17,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     file: string;
     file2: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -17,6 +17,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     file: string;
     file2: string;
     description: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -17,7 +17,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     file: string;
     file2: string;
     description: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -24,7 +24,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     icons: IconsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -24,6 +24,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     icons: IconsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -24,9 +24,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     icons: IconsPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -52,7 +52,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;
@@ -125,7 +128,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;
@@ -189,7 +195,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -52,9 +52,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
@@ -128,9 +125,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
@@ -195,9 +189,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -52,6 +52,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;
@@ -124,6 +125,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;
@@ -187,6 +189,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -24,6 +24,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -24,7 +24,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -24,9 +24,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -28,9 +28,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     dataSource: {} | { caption: string } | { type: string } | null;
     reference: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -28,6 +28,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     dataSource: {} | { caption: string } | { type: string } | null;
     reference: string;
     referenceSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -28,7 +28,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     dataSource: {} | { caption: string } | { type: string } | null;
     reference: string;
     referenceSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-attribute-refset.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-attribute-refset.ts
@@ -27,6 +27,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode?: "design" | "xray" | "structure";
     dataSource: {} | { caption: string } | { type: string } | null;
     referenceDefault: string;
     reference: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -22,9 +22,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -22,6 +22,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -22,7 +22,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -22,9 +22,6 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -22,6 +22,7 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -22,7 +22,10 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
@@ -30,7 +30,10 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
     selectionAll: "None" | "Single" | "Multi";
     selectionSingleMulti: "Single" | "Multi";
     selectionMulti: "Multi";

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
@@ -30,6 +30,7 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
     selectionAll: "None" | "Single" | "Multi";
     selectionSingleMulti: "Single" | "Multi";
     selectionMulti: "Multi";

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
@@ -30,9 +30,6 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
     selectionAll: "None" | "Single" | "Multi";
     selectionSingleMulti: "Single" | "Multi";

--- a/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -27,9 +27,6 @@ export function generatePreviewTypes(
             : ""
     }
     readOnly: boolean;
-    /**
-     * Introduced in version 10.11.0 otherwise it will be undefined
-     */
     renderMode?: "design" | "xray" | "structure";
 ${generatePreviewTypeBody(properties, results, resolveProp)}
 }`);

--- a/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -27,7 +27,10 @@ export function generatePreviewTypes(
             : ""
     }
     readOnly: boolean;
-    renderMode: "design" | "xray" | "structure";
+    /**
+     * Introduced in version 10.11.0 otherwise it will be undefined
+     */
+    renderMode?: "design" | "xray" | "structure";
 ${generatePreviewTypeBody(properties, results, resolveProp)}
 }`);
     return results;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -27,6 +27,7 @@ export function generatePreviewTypes(
             : ""
     }
     readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
 ${generatePreviewTypeBody(properties, results, resolveProp)}
 }`);
     return results;


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ❌
-   Compatible with: MX 10
-   Did you update version and changelog? ✅
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [ ] Bug fix
-   [X ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)


## What is the purpose of this PR?
This PR will introduce a new parameter to the generated pluggable widgets that will allow users to change the rendering according to which mode the canvas is currently in.


## Relevant changes
Add a field to the generator for pluggable widget preview properties that can take one of 3 values, namely "xray", "design" and "structure"


## What should be covered while testing?
Check that generated widget preview properties has the "renderMode: "xray", "design", "structure";" property added
