### PR TITLE
[PAG-2505] Update generatePreviewTypes to add translate function

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added the translate function to the preview arguments. This can be used to translate texts show in the widget preview.
+
 ### Changed
+
+-   The renderMode property in the preview arguments is no longer considered optional.
 
 #### Rollup 3
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/association.ts
@@ -27,7 +27,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     reference: string;
     referenceSet: string;
     referenceOrSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/atribute-linked-action.ts
@@ -14,7 +14,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     collapsed: string;
     onToggleCollapsed: {} | null;
 }
@@ -52,7 +53,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     onToggleCollapsed: {} | null;
     datasourceProperties: DatasourcePropertiesPreviewType[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/containment.ts
@@ -25,7 +25,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
     description: string;
     action: {} | null;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/datasource.ts
@@ -52,7 +52,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     contentSource: {} | { caption: string } | { type: string } | null;
     optionalSource: {} | { caption: string } | { type: string } | null;
     content: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/expression.ts
@@ -29,7 +29,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     myDataSource: {} | { caption: string } | { type: string } | null;
     expressionReturnTypeType: string;
     expressionReturnTypeTypeDataSource: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/file.ts
@@ -17,7 +17,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     file: string;
     file2: string;
     description: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/icon.ts
@@ -24,7 +24,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     icons: IconsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/index.ts
@@ -52,7 +52,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;
@@ -125,7 +126,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;
@@ -189,7 +191,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     valueAttribute: string;
     mywidgetValue: string;
     valueExpression: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-action.ts
@@ -24,7 +24,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-association.ts
@@ -28,7 +28,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     dataSource: {} | { caption: string } | { type: string } | null;
     reference: string;
     referenceSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-attribute-refset.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-attribute-refset.ts
@@ -27,7 +27,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     dataSource: {} | { caption: string } | { type: string } | null;
     referenceDefault: string;
     reference: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-files.ts
@@ -22,7 +22,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/list-image.ts
@@ -22,7 +22,8 @@ export interface MyWidgetContainerProps {
 
 export interface MyWidgetPreviewProps {
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     actions: ActionsPreviewType[];
 }
 `;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/metadata-association.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/metadata-association.ts
@@ -25,7 +25,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     data: {} | { caption: string } | { type: string } | null;
     metaReference: string;
     metaReferenceSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/metadata-attribute.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/metadata-attribute.ts
@@ -26,7 +26,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     data: {} | { caption: string } | { type: string } | null;
     metaString: string;
     metaNumberDate: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/non-linked-list-attribute-refset.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/non-linked-list-attribute-refset.ts
@@ -26,7 +26,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     referenceDefault: string;
     reference: string;
     referenceSet: string;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/selection.ts
@@ -30,7 +30,8 @@ export interface MyWidgetPreviewProps {
     style: string;
     styleObject?: CSSProperties;
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
     selectionAll: "None" | "Single" | "Multi";
     selectionSingleMulti: "Single" | "Multi";
     selectionMulti: "Multi";

--- a/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generatePreviewTypes.ts
@@ -27,7 +27,8 @@ export function generatePreviewTypes(
             : ""
     }
     readOnly: boolean;
-    renderMode?: "design" | "xray" | "structure";
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
 ${generatePreviewTypeBody(properties, results, resolveProp)}
 }`);
     return results;
@@ -40,8 +41,7 @@ function generatePreviewTypeBody(
 ) {
     return properties
         .filter(prop => {
-            if (prop.$.type === "datasource" && prop.$.isLinked)
-                return false;
+            if (prop.$.type === "datasource" && prop.$.isLinked) return false;
             return true;
         })
         .map(prop => `    ${prop.$.key}: ${toPreviewPropType(prop, generatedTypes, resolveProp)};`)


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅
-   Contains breaking changes ❌
-   Compatible with: MX 9️⃣
-   Did you update version and changelog? ✅ ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅

## This PR contains

-   [ x ] Bug fix
-   [ x ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

PAG added the translate function to the preview props, this adds the appropriate typing. We also noticed that the type for the mode (design, structure, x-ray) was made nullable on accident.

## Relevant changes

Generated types for the preview props.

## What should be covered while testing?

The updated unit tests should be sufficient.
