### PR TITLE
Fix import of commonJS module with no default

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed an issue with loading custom rollup configs.
+
 ## [10.18.1] - 2025-03-11
 
 ### Fixed

--- a/packages/pluggable-widgets-tools/configs/rollup.config.mjs
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.mjs
@@ -13,7 +13,7 @@ import typescript from "@rollup/plugin-typescript";
 import colors from "ansi-colors";
 import postcssImport from "postcss-import";
 import postcssUrl from "postcss-url";
-import loadConfigFile from "rollup/dist/loadConfigFile.js";
+import rollupLoadConfigFile from "rollup/dist/loadConfigFile.js";
 import clear from "rollup-plugin-clear";
 import command from "rollup-plugin-command";
 import license from "rollup-plugin-license";
@@ -37,6 +37,7 @@ import {
 import { copyLicenseFile, createMpkFile, licenseCustomTemplate } from "./helpers/rollup-helper.mjs";
 import url from "./rollup-plugin-assets.mjs";
 
+const { loadConfigFile } = rollupLoadConfigFile;
 const { cp } = shelljs;
 
 const outDir = join(sourcePath, "/dist/tmp/widgets/");

--- a/packages/pluggable-widgets-tools/package-lock.json
+++ b/packages/pluggable-widgets-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.18.1",
+  "version": "10.18.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/pluggable-widgets-tools",
-      "version": "10.18.1",
+      "version": "10.18.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.26.0",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.18.1",
+  "version": "10.18.2",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
PR #117 addressed an import of a common js module that assumed it had a named export, which caused an error in some environments. It appears that this fix broke other widgets with custom configuration as the imported module does not have a default exported member.

This PR addresses both issues. It has been verified with the widgets that broke before and after 10.18.1.