### PR TITLE
[WTF-2256] Throw non-empty directory error using preferred mechanism

### DIFF
--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- We fixed the error that is thrown when the target directory is not empty. (#123)
+
 ## [10.15.0] - 2024-09-24
 
 ### Changed

--- a/packages/generator-widget/generators/app/index.js
+++ b/packages/generator-widget/generators/app/index.js
@@ -32,7 +32,7 @@ class MxGenerator extends Generator {
 
         if ((await dirExists(fullDestinationPath)) && !(await isDirEmpty(fullDestinationPath))) {
             this.log(text.BANNER);
-            this.env.error(Error(text.DIR_NOT_EMPTY_ERROR));
+            throw new Error(text.DIR_NOT_EMPTY_ERROR);
         }
     }
 

--- a/packages/generator-widget/package-lock.json
+++ b/packages/generator-widget/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "10.15.0",
+  "version": "10.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mendix/generator-widget",
-      "version": "10.15.0",
+      "version": "10.15.1",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/packages/generator-widget/package.json
+++ b/packages/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "10.15.0",
+  "version": "10.15.1",
   "description": "Mendix Pluggable Widgets Generator",
   "engines": {
     "node": ">=16"


### PR DESCRIPTION
#123 reported that the generator does not throw an understandable error when the target directory is non-empty. A check for this already existed, but the mechanism used for reporting the error no longer seems to be supported by yeoman. This PR fixes the situation by throwing the error instead, which is the preferred mechanism described in the yeoman docs.

## Checklist

-   Contains unit tests ❌
-   Contains breaking changes  ❌
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ ❌

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

To address the not understandable error reported by issue #123

## Relevant changes

Used a different mechanism for raising the error. The previous method seems to have been an internal api that was not officially documented but recommended on stack overflow.

## What should be covered while testing?

Try generating a widget in a directory that is not empty. I.e.:

```
# First check out this branch and run `npm install` inside the generator-widget package.

mkdir testWidget
touch testWidget/foo

yo /path/to/widgets-tools/packages/generator-widget/generators/app TestWidget
```

