### PR TITLE
[]: Bump TS target of jest configs to es2019

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+-   We fixed an issue with unit tests failing when files contain modern JavaScript features.
+
 ## [10.21.1] - 2025-06-13
 
 ### Added

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "10.21.1",
+  "version": "10.21.2",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=20"

--- a/packages/pluggable-widgets-tools/test-config/jest.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.config.js
@@ -13,7 +13,7 @@ module.exports = {
         "^.+\\.tsx?$": [
             "ts-jest",
             {
-                tsconfig: { module: "commonjs" }
+                tsconfig: { module: "commonjs", target: "ES2019" },
             }
         ],
         "^.+\\.jsx?$": join(__dirname, "transform.js"),

--- a/packages/pluggable-widgets-tools/test-config/jest.enzyme-free.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.enzyme-free.config.js
@@ -12,7 +12,7 @@ module.exports = {
         "^.+\\.tsx?$": [
             "ts-jest",
             {
-                tsconfig: { module: "commonjs" }
+                tsconfig: { module: "commonjs", target: "ES2019" },
             }
         ],
         "^.+\\.jsx?$": join(__dirname, "transform.js"),

--- a/packages/pluggable-widgets-tools/test-config/jest.native.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.native.config.js
@@ -23,7 +23,7 @@ module.exports = {
         "^.+\\.tsx?$": [
             "ts-jest",
             {
-                tsconfig: { module: "commonjs" }
+                tsconfig: { module: "commonjs", target: "ES2019" },
             }
         ],
         "^.+\\.jsx?$": join(__dirname, "transform-native.js")


### PR DESCRIPTION
This target is supported by node 12+ and the tests are running in node environment only, so this is safe.

## Checklist


-   Contains breaking changes  ❌
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [x] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

The jest config was not fully configured to support modern JS features while the main config does support them and works correctly. This PR bumps typescript target to 'es2019' which is supported by node12+, so this should be safe to not introduce breaking changes.