### PR TITLE
[PAG-2696] Add prompt attribute to widget xml

### DIFF
--- a/packages/generator-widget/README.md
+++ b/packages/generator-widget/README.md
@@ -35,6 +35,7 @@ The Mendix Pluggable Widget Generator is a scaffolding tool to let you quickly c
 
     - Widget name
     - Description
+    - Prompt
     - Organization
     - Copyright
     - License

--- a/packages/generator-widget/generators/app/lib/prompttexts.js
+++ b/packages/generator-widget/generators/app/lib/prompttexts.js
@@ -22,6 +22,12 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
         },
         {
             type: "input",
+            name: "prompt",
+            message: "Enter prompt for your widget (optional)",
+            default: ""
+        },
+        {
+            type: "input",
             name: "organization",
             message: "Organization name",
             default: "Mendix",
@@ -31,7 +37,7 @@ function promptWidgetProperties(mxProjectDir, widgetName) {
             type: "input",
             name: "copyright",
             message: "Add a copyright",
-            default: "© Mendix Technology BV 2022. All rights reserved.",
+            default: `© Mendix Technology BV ${new Date().getFullYear()}. All rights reserved.`,
             store: true
         },
         {

--- a/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJs/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="yourName" type="string" required="false">
                 <caption>Name</caption>
                 <description>Enter your name</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateJsFn/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="yourName" type="string" required="false">
                 <caption>Name</caption>
                 <description>Enter your name</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTs/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="yourName" type="string" required="false">
                 <caption>Name</caption>
                 <description>Enter your name</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/emptyTemplateTsFn/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="yourName" type="string" required="false">
                 <caption>Name</caption>
                 <description>Enter your name</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateJs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateJs/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="value" type="attribute" required="false">
                 <caption>Value</caption>
                 <description>The attribute that contains the value for the badge</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -26,6 +28,7 @@
             <property key="onClick" type="action" required="false">
                 <caption>On click</caption>
                 <description>Action to trigger when the badge is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateJsFn/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="value" type="attribute" required="false">
                 <caption>Value</caption>
                 <description>The attribute that contains the value for the badge</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -26,6 +28,7 @@
             <property key="onClick" type="action" required="false">
                 <caption>On click</caption>
                 <description>Action to trigger when the badge is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateTs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateTs/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="value" type="attribute" required="false">
                 <caption>Value</caption>
                 <description>The attribute that contains the value for the badge</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -26,6 +28,7 @@
             <property key="onClick" type="action" required="false">
                 <caption>On click</caption>
                 <description>Action to trigger when the badge is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/native/fullTemplateTsFn/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="value" type="attribute" required="false">
                 <caption>Value</caption>
                 <description>The attribute that contains the value for the badge</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -26,6 +28,7 @@
             <property key="onClick" type="action" required="false">
                 <caption>On click</caption>
                 <description>Action to trigger when the badge is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJs/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="sampleText" type="string" required="false">
                 <caption>Default value</caption>
                 <description>Sample text input</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateJsFn/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="sampleText" type="string" required="false">
                 <caption>Default value</caption>
                 <description>Sample text input</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTs/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="sampleText" type="string" required="false">
                 <caption>Default value</caption>
                 <description>Sample text input</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/emptyTemplateTsFn/src/WidgetName.xml.ejs
@@ -5,12 +5,14 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon/>
     <properties>
         <propertyGroup caption="General">
             <property key="sampleText" type="string" required="false">
                 <caption>Default value</caption>
                 <description>Sample text input</description>
+                <% if (prompt) { %><prompt>Sample prompt for Maia</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateJs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateJs/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="valueAttribute" type="attribute" required="false">
                 <caption>Value attribute</caption>
                 <description>The attribute that contains the <%- packageName %> value</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -24,12 +26,14 @@
             <property key="<%- packageName %>Value" type="string" required="false">
                 <caption>Default value</caption>
                 <description>The <%- packageName %> value shown when no value is provided via the attribute</description>
+                <% if (prompt) { %><prompt>Set the default value if no attribute is provided</prompt><% } %>
             </property>
         </propertyGroup>
         <propertyGroup caption="Display">
             <property key="bootstrapStyle" type="enumeration" defaultValue="default">
                 <caption><%- name %> style</caption>
                 <description>The appearance of the <%- packageName %></description>
+                <% if (prompt) { %><prompt>Choose the widgets style</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="default">Default</enumerationValue>
                     <enumerationValue key="primary">Primary</enumerationValue>
@@ -43,6 +47,7 @@
             <property key="<%- packageName %>Type" type="enumeration" required="true" defaultValue="badge">
                 <caption>Type</caption>
                 <description>Render it as either a badge or a color label</description>
+                <% if (prompt) { %><prompt>Choose between  types</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="badge">Badge</enumerationValue>
                     <enumerationValue key="label">Label</enumerationValue>
@@ -53,6 +58,7 @@
             <property key="onClickAction" type="action" required="false">
                 <caption>On click action</caption>
                 <description>Action to trigger when button / label is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateJsFn/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="valueAttribute" type="attribute" required="false">
                 <caption>Value attribute</caption>
                 <description>The attribute that contains the <%- packageName %> value</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -24,12 +26,14 @@
             <property key="<%- packageName %>Value" type="string" required="false">
                 <caption>Default value</caption>
                 <description>The <%- packageName %> value shown when no value is provided via the attribute</description>
+                <% if (prompt) { %><prompt>Set the default value if no attribute is provided</prompt><% } %>
             </property>
         </propertyGroup>
         <propertyGroup caption="Display">
             <property key="bootstrapStyle" type="enumeration" defaultValue="default">
                 <caption><%- name %> style</caption>
                 <description>The appearance of the <%- packageName %></description>
+                <% if (prompt) { %><prompt>Choose the widgets style</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="default">Default</enumerationValue>
                     <enumerationValue key="primary">Primary</enumerationValue>
@@ -43,6 +47,7 @@
             <property key="<%- packageName %>Type" type="enumeration" required="true" defaultValue="badge">
                 <caption>Type</caption>
                 <description>Render it as either a badge or a color label</description>
+                <% if (prompt) { %><prompt>Choose between  types</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="badge">Badge</enumerationValue>
                     <enumerationValue key="label">Label</enumerationValue>
@@ -53,6 +58,7 @@
             <property key="onClickAction" type="action" required="false">
                 <caption>On click action</caption>
                 <description>Action to trigger when button / label is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateTs/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="valueAttribute" type="attribute" required="false">
                 <caption>Value attribute</caption>
                 <description>The attribute that contains the <%- packageName %> value</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -24,12 +26,14 @@
             <property key="<%- packageName %>Value" type="string" required="false">
                 <caption>Default value</caption>
                 <description>The <%- packageName %> value shown when no value is provided via the attribute</description>
+                <% if (prompt) { %><prompt>Set the default value if no attribute is provided</prompt><% } %>
             </property>
         </propertyGroup>
         <propertyGroup caption="Display">
             <property key="bootstrapStyle" type="enumeration" defaultValue="default">
                 <caption><%- name %> style</caption>
                 <description>The appearance of the <%- packageName %></description>
+                <% if (prompt) { %><prompt>Choose the widgets style</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="default">Default</enumerationValue>
                     <enumerationValue key="primary">Primary</enumerationValue>
@@ -43,6 +47,7 @@
             <property key="<%- packageName %>Type" type="enumeration" required="true" defaultValue="badge">
                 <caption>Type</caption>
                 <description>Render it as either a badge or a color label</description>
+                <% if (prompt) { %><prompt>Choose between  types</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="badge">Badge</enumerationValue>
                     <enumerationValue key="label">Label</enumerationValue>
@@ -53,6 +58,7 @@
             <property key="onClickAction" type="action" required="false">
                 <caption>On click action</caption>
                 <description>Action to trigger when button / label is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>

--- a/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.xml.ejs
+++ b/packages/generator-widget/generators/app/templates/pluggable/web/fullTemplateTsFn/src/WidgetName.xml.ejs
@@ -5,6 +5,7 @@
         xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../node_modules/mendix/custom_widget.xsd">
     <name><%- nameCamelCase %></name>
     <description><%- description %></description>
+    <% if (prompt) { %><prompt><%- prompt %></prompt><% } %>
     <icon>
         iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAABp1BMVEUAAABV//9mzP9LtP9Ms/9Jtv9NsvdJsfpLtPpJsfdJsfhJsvhJsvdKsvdJsPhKsPhJsfdJsPhJsfdIsfhJsfdIsPdJsfhJsfhJsPhJsPhIsfhIsPdJsPdKsPdKsfdNsvdOsvdPs/dQs/dRtPdStPdTtPdUtfdWtvdXtvdauPdcuPdeufdeufhguvhiu/hju/hkvPhmvfhnvfhpvvhrv/huwPhvwfhxwfhywvhzwvh4xfl5xfl6xfl8xvl9xvl9x/mByPmCyfmFyvmGyvmJzPmKzPmLzfmNzvqPzvqQz/qT0PqU0PqU0fqX0vqY0vqa0/qe1fqg1vqj1/uk1/un2fup2vut2/uv3Puw3Puw3fuz3vu13/u23/u34Pu44Pu64fu64fy84vy94vy+4/y/4/zD5fzE5fzG5vzH5vzI5/zK6PzL6PzR6/zT7P3U7P3V7f3W7f3Y7v3Z7v3c8P3e8f3f8f3g8f3i8v3l8/3l9P3n9P3r9v7t9/7u9/7v+P7w+P7x+f7y+f70+v71+v74/P75/P76/f77/f78/f78/v79/v7+/v7////6dMsRAAAAG3RSTlMAAwURGxwhMTNic3SEh4iVp7XBzejt7vH5/f6PsMNWAAABsklEQVR4AWIYfGAUjIJRMAqYuYREJKWJAqLCPGwY+jnFpEkBEryMqPr5pEkFgkwo9kuTDviR/S9GhgFSHAgDuKXJAQIIA4TIMkAcEY4i0mQBVrgBkuQZwA43QJo8wIFhQEhEOIBQOutHJozDOP5Crp4e1RhkJ0tKGJFd6oNEdtmJyEIzpaZl5nrRZgaHM/2Pf5/vwXXfyagXgG93bwSAlEolowLMm9w83gibhXH2gKKVdD67gTnWjwCk+VVjMQS4suSnnjMLRVFc9sAHvAX2A9fySaXNBMbEZVUWscaHIMRuqwBgD8hDEbnsRmfjUKJkAQZGCTlO/xWBwIADQLIZBlY441MvfoF1xlFS/4fy+bzXKh4dgNJE7L3eh3tmtuWa+AMcMIY3dgUvZQpGEYmMw2kD7HC+R29UqyoXLaBd0QZxzgXgikLLDSqJTKU5HOcS0MsbA9jPqtwCRvXm2eorBbNIJBw3KJ9O4Yl+AAXdnyaLt7PWN3jRWLvzmAVp94zO5+n41/onfo/UpExxZqI0O7NQr0DhIq9Io7hQpbRYp7hiobRqo6ByFcNWuY6CUTAKRgEAo8X0lBD3V30AAAAASUVORK5CYII=
     </icon>
@@ -13,6 +14,7 @@
             <property key="valueAttribute" type="attribute" required="false">
                 <caption>Value attribute</caption>
                 <description>The attribute that contains the <%- packageName %> value</description>
+                <% if (prompt) { %><prompt>Specify the attribute holding the widgets value</prompt><% } %>
                 <attributeTypes>
                     <attributeType name="String"/>
                     <attributeType name="Enum"/>
@@ -24,12 +26,14 @@
             <property key="<%- packageName %>Value" type="string" required="false">
                 <caption>Default value</caption>
                 <description>The <%- packageName %> value shown when no value is provided via the attribute</description>
+                <% if (prompt) { %><prompt>Set the default value if no attribute is provided</prompt><% } %>
             </property>
         </propertyGroup>
         <propertyGroup caption="Display">
             <property key="bootstrapStyle" type="enumeration" defaultValue="default">
                 <caption><%- name %> style</caption>
                 <description>The appearance of the <%- packageName %></description>
+                <% if (prompt) { %><prompt>Choose the widgets style</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="default">Default</enumerationValue>
                     <enumerationValue key="primary">Primary</enumerationValue>
@@ -43,6 +47,7 @@
             <property key="<%- packageName %>Type" type="enumeration" required="true" defaultValue="badge">
                 <caption>Type</caption>
                 <description>Render it as either a badge or a color label</description>
+                <% if (prompt) { %><prompt>Choose between  types</prompt><% } %>
                 <enumerationValues>
                     <enumerationValue key="badge">Badge</enumerationValue>
                     <enumerationValue key="label">Label</enumerationValue>
@@ -53,6 +58,7 @@
             <property key="onClickAction" type="action" required="false">
                 <caption>On click action</caption>
                 <description>Action to trigger when button / label is clicked</description>
+                <% if (prompt) { %><prompt>Specify the action triggered when the widget is clicked</prompt><% } %>
             </property>
         </propertyGroup>
     </properties>


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ❌
-   Compatible with: MX 11
-   Did you update version and changelog? ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

Adding prompt attribute to xml file and to widget generator questions.

## Relevant changes

- Added optional "prompt" question during setup which is going to be used on widget level.
- Added "prompt" attributes to widget level and to properties level to all xml templates.

## What should be covered while testing?

Generating a widget using the bin.js script.