### PR TITLE
[WTF-2406] Generate types for single object data sources

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 -   We added support for the `allowUpload` attribute on image properties in native widgets, generating `EditableImageValue<NativeImage>` when enabled, introduced in Mendix 11.11.
+-   We added support for single object datasource properties, introduced in Mendix 11.11.
 
 ### Changed
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/index.spec.ts
@@ -47,6 +47,8 @@ import {listActionWithVariablesInput, listActionWithVariablesInputNative} from "
 import {listActionWithVariablesOutput, listActionWithVariablesOutputNative} from "./outputs/list-action-with-variables";
 import {imageWebInput, imageNativeInput} from "./inputs/image";
 import {imageWebOutput, imageNativeOutput} from "./outputs/image";
+import { singleObjectDatasourceInput, singleObjectDatasourceInputNative } from "./inputs/single-object-datasource";
+import { singleObjectDatasourceNativeOutput, singleObjectDatasourceWebOutput } from "./outputs/single-object-datasource";
 
 describe("Generating tests", () => {
     it("Generates a parsed typing from XML for native", () => {
@@ -247,6 +249,16 @@ describe("Generating tests", () => {
      it("Generates a parsed typing from XML for native using images", () => {
         const newContent = generateNativeTypesFor(imageNativeInput);
         expect(newContent).toBe(imageNativeOutput);
+    });
+
+    it("Generates a parsed typing from XML for web using single object datasource", () => {
+        const newContent = generateFullTypesFor(singleObjectDatasourceInput);
+        expect(newContent).toBe(singleObjectDatasourceWebOutput);
+    });
+
+    it("Generates a parsed typing from XML for native using single object datasource", () => {
+        const newContent = generateNativeTypesFor(singleObjectDatasourceInputNative);
+        expect(newContent).toBe(singleObjectDatasourceNativeOutput);
     });
 });
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/single-object-datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/single-object-datasource.ts
@@ -1,0 +1,136 @@
+export const singleObjectDatasourceInput = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="singleSource" type="datasource" isList="false">
+                <caption>Single object data source</caption>
+                <description />
+            </property>
+            <property key="optionalSingleSource" type="datasource" isList="false" required="false">
+                <caption>Optional single object data source</caption>
+                <description />
+            </property>
+            <property key="listSource" type="datasource" isList="true">
+                <caption>List data source</caption>
+                <description />
+            </property>
+            <property key="singleContent" type="widgets" dataSource="singleSource">
+                <caption>Single Content</caption>
+                <description />
+            </property>
+            <property key="singleAttribute" type="attribute" dataSource="singleSource">
+                <caption>Single Attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Boolean"/>
+                    <attributeType name="Decimal"/>
+                </attributeTypes>
+            </property>
+            <property key="singleAction" type="action" dataSource="singleSource">
+                <caption>Single Action</caption>
+                <description />
+            </property>
+            <property key="singleTextTemplate" type="textTemplate" dataSource="singleSource">
+                <caption>Single Text Template</caption>
+                <description />
+            </property>
+            <property key="singleExpression" type="expression" dataSource="singleSource">
+                <caption>Single Expression</caption>
+                <description />
+                <returnType type="Decimal"/>
+            </property>
+            <property key="optionalSingleAttribute" type="attribute" dataSource="optionalSingleSource">
+                <caption>Optional Single Attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="optionalSingleAction" type="action" dataSource="optionalSingleSource">
+                <caption>Optional Single Action</caption>
+                <description />
+            </property>
+            <property key="listContent" type="widgets" dataSource="listSource">
+                <caption>List Content</caption>
+                <description />
+            </property>
+            <property key="listAttribute" type="attribute" dataSource="listSource">
+                <caption>List Attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="listAction" type="action" dataSource="listSource">
+                <caption>List Action</caption>
+                <description />
+            </property>
+        </propertyGroup>
+        <propertyGroup caption="System Properties">
+            <systemProperty key="Label"></systemProperty>
+            <systemProperty key="TabIndex"></systemProperty>
+        </propertyGroup>
+    </properties>
+</widget>`;
+
+export const singleObjectDatasourceInputNative = `<?xml version="1.0" encoding="utf-8"?>
+<widget id="mendix.mywidget.MyWidget" needsEntityContext="true" offlineCapable="true" pluginWidget="true" supportedPlatform="Native"
+        xmlns="http://www.mendix.com/widget/1.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.mendix.com/widget/1.0/ ../xsd/widget.xsd">
+    <properties>
+        <propertyGroup caption="General">
+            <property key="singleSource" type="datasource" isList="false">
+                <caption>Single object data source</caption>
+                <description />
+            </property>
+            <property key="listSource" type="datasource" isList="true">
+                <caption>List data source</caption>
+                <description />
+            </property>
+            <property key="singleContent" type="widgets" dataSource="singleSource">
+                <caption>Single Content</caption>
+                <description />
+            </property>
+            <property key="singleAttribute" type="attribute" dataSource="singleSource">
+                <caption>Single Attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                    <attributeType name="Boolean"/>
+                    <attributeType name="Decimal"/>
+                </attributeTypes>
+            </property>
+            <property key="singleAction" type="action" dataSource="singleSource">
+                <caption>Single Action</caption>
+                <description />
+            </property>
+            <property key="singleTextTemplate" type="textTemplate" dataSource="singleSource">
+                <caption>Single Text Template</caption>
+                <description />
+            </property>
+            <property key="singleExpression" type="expression" dataSource="singleSource">
+                <caption>Single Expression</caption>
+                <description />
+                <returnType type="Decimal"/>
+            </property>
+            <property key="listContent" type="widgets" dataSource="listSource">
+                <caption>List Content</caption>
+                <description />
+            </property>
+            <property key="listAttribute" type="attribute" dataSource="listSource">
+                <caption>List Attribute</caption>
+                <description />
+                <attributeTypes>
+                    <attributeType name="String"/>
+                </attributeTypes>
+            </property>
+            <property key="listAction" type="action" dataSource="listSource">
+                <caption>List Action</caption>
+                <description />
+            </property>
+        </propertyGroup>
+    </properties>
+</widget>`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/single-object-datasource.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/single-object-datasource.ts
@@ -1,0 +1,62 @@
+export const singleObjectDatasourceWebOutput = `/**
+ * This file was generated from MyWidget.xml
+ * WARNING: All changes made to this file will be overwritten
+ * @author Mendix Widgets Framework Team
+ */
+import { ActionValue, DynamicValue, EditableValue, ListActionValue, ListAttributeValue, ListValue, ListWidgetValue, ObjectItem } from "mendix";
+import { ComponentType, ReactNode } from "react";
+import { Big } from "big.js";
+
+export interface MyWidgetContainerProps {
+    name: string;
+    tabIndex?: number;
+    id: string;
+    singleSource: DynamicValue<ObjectItem>;
+    optionalSingleSource?: DynamicValue<ObjectItem>;
+    listSource: ListValue;
+    singleContent: ReactNode;
+    singleAttribute: EditableValue<string | boolean | Big>;
+    singleAction?: ActionValue;
+    singleTextTemplate: DynamicValue<string>;
+    singleExpression: DynamicValue<Big>;
+    optionalSingleAttribute?: EditableValue<string>;
+    optionalSingleAction?: ActionValue;
+    listContent: ListWidgetValue;
+    listAttribute: ListAttributeValue<string>;
+    listAction?: ListActionValue;
+}
+
+export interface MyWidgetPreviewProps {
+    readOnly: boolean;
+    renderMode: "design" | "xray" | "structure";
+    translate: (text: string) => string;
+    singleSource: {} | { caption: string } | { type: string } | null;
+    optionalSingleSource: {} | { caption: string } | { type: string } | null;
+    listSource: {} | { caption: string } | { type: string } | null;
+    singleContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
+    singleAttribute: string;
+    singleAction: {} | null;
+    singleTextTemplate: string;
+    singleExpression: string;
+    optionalSingleAttribute: string;
+    optionalSingleAction: {} | null;
+    listContent: { widgetCount: number; renderer: ComponentType<{ children: ReactNode; caption?: string }> };
+    listAttribute: string;
+    listAction: {} | null;
+}
+`;
+
+export const singleObjectDatasourceNativeOutput = `export interface MyWidgetProps<Style> {
+    name: string;
+    style: Style[];
+    singleSource: DynamicValue<ObjectItem>;
+    listSource: ListValue;
+    singleContent: ReactNode;
+    singleAttribute: EditableValue<string | boolean | Big>;
+    singleAction?: ActionValue;
+    singleTextTemplate: DynamicValue<string>;
+    singleExpression: DynamicValue<Big>;
+    listContent: ListWidgetValue;
+    listAttribute: ListAttributeValue<string>;
+    listAction?: ListActionValue;
+}`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generate.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generate.ts
@@ -25,6 +25,7 @@ const importableModules = [
         "ListWidgetValue",
         "NativeIcon",
         "NativeImage",
+        "ObjectItem",
         "Option",
         "ReferenceSetValue",
         "ReferenceValue",

--- a/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -100,6 +100,10 @@ export function hasOptionalDataSource(prop: Property, resolveProp: (key: string)
     return prop.$.dataSource && resolveProp(prop.$.dataSource)?.$.required === "false";
 }
 
+function isLinkedToListDataSource(prop: Property, resolveProp: (key: string) => Property | undefined): boolean {
+    return prop.$.dataSource != null && resolveProp(prop.$.dataSource)?.$.isList === "true";
+}
+
 function toActionVariablesOutputType(actionVariables?: ActionVariableTypes[]) {
     const types = actionVariables?.flatMap(av => av.actionVariable)
         .map(avt => `${avt.$.key}: ${toOption(toAttributeClientType(avt.$.type))}`)
@@ -121,9 +125,9 @@ function toClientPropType(
             return "string";
         case "action":
             const variableTypes = toActionVariablesOutputType(prop.actionVariables);
-            return (prop.$.dataSource ? "ListActionValue" : "ActionValue") + variableTypes;
+            return (isLinkedToListDataSource(prop, resolveProp) ? "ListActionValue" : "ActionValue") + variableTypes;
         case "textTemplate":
-            return prop.$.dataSource ? "ListExpressionValue<string>" : "DynamicValue<string>";
+            return isLinkedToListDataSource(prop, resolveProp) ? "ListExpressionValue<string>" : "DynamicValue<string>";
         case "integer":
             return "number";
         case "decimal":
@@ -136,7 +140,7 @@ function toClientPropType(
         case "file":
             return prop.$.allowUpload ? "EditableFileValue" : "DynamicValue<FileValue>";
         case "datasource":
-            return "ListValue";
+            return prop.$.isList === "true" ? "ListValue" : "DynamicValue<ObjectItem>";
         case "attribute": {
             if (!prop.attributeTypes?.length) {
                 throw new Error("[XML] Attribute property requires attributeTypes element");
@@ -145,22 +149,22 @@ function toClientPropType(
                 .flatMap(ats => ats.attributeType)
                 .map(at => toAttributeClientType(at.$.name));
             const unionType = toUniqueUnionType(types);
-            const linkedToDataSource = !!prop.$.dataSource;
+            const linkedToListDS = isLinkedToListDataSource(prop, resolveProp);
 
             if (prop.$.isMetaData === "true") {
-                if (!linkedToDataSource) {
+                if (!prop.$.dataSource) {
                     throw new Error(`[XML] Attribute property can only have isMetaData="true" when linked to a datasource`);
                 }
                 return `AttributeMetaData<${unionType}>`;
             }
 
             if (!prop.associationTypes?.length) {
-                return toAttributeOutputType("Reference", linkedToDataSource, unionType);
+                return toAttributeOutputType("Reference", linkedToListDS, unionType);
             }
             else {
                 const reftypes = prop.associationTypes
                     .flatMap(ats => ats.associationType)
-                    .map(at => toAttributeOutputType(at.$.name, linkedToDataSource, unionType));
+                    .map(at => toAttributeOutputType(at.$.name, linkedToListDS, unionType));
                 return toUniqueUnionType(reftypes);
             }
         }
@@ -169,9 +173,9 @@ function toClientPropType(
                 throw new Error("[XML] Association property requires associationTypes element");
             }
 
-            const linkedToDataSource = !!prop.$.dataSource;
+            const linkedToListDS = isLinkedToListDataSource(prop, resolveProp);
             if (prop.$.isMetaData === "true") {
-                if (!linkedToDataSource) {
+                if (!prop.$.dataSource) {
                     throw new Error(`[XML] Association property can only have isMetaData="true" when linked to a datasource`);
                 }
                 return "AssociationMetaData";
@@ -179,7 +183,7 @@ function toClientPropType(
 
             const types = prop.associationTypes
                 .flatMap(ats => ats.associationType)
-                .map(at => toAssociationOutputType(at.$.name, linkedToDataSource));
+                .map(at => toAssociationOutputType(at.$.name, linkedToListDS));
             return toUniqueUnionType(types);
         }
         case "expression":
@@ -187,7 +191,7 @@ function toClientPropType(
                 throw new Error("[XML] Expression property requires returnType element");
             }
             const type = toExpressionClientType(prop.returnType[0], resolveProp);
-            return prop.$.dataSource ? `ListExpressionValue<${type}>` : `DynamicValue<${type}>`;
+            return isLinkedToListDataSource(prop, resolveProp) ? `ListExpressionValue<${type}>` : `DynamicValue<${type}>`;
         case "enumeration":
             const typeName = capitalizeFirstLetter(prop.$.key) + "Enum";
             generatedTypes.push(generateEnum(typeName, prop));
@@ -209,7 +213,7 @@ ${generateClientTypeBody(childProperties, isNative, generatedTypes, resolveChild
             );
             return prop.$.isList === "true" ? `${childType}[]` : childType;
         case "widgets":
-            return prop.$.dataSource ? "ListWidgetValue" : "ReactNode";
+            return isLinkedToListDataSource(prop, resolveProp) ? "ListWidgetValue" : "ReactNode";
         case "selection":
             if (!prop.selectionTypes?.length) {
                 throw new Error("[XML] Selection property requires selectionTypes element");


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ❌
-   Did you update version and changelog? ✅ ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ ❌

## This PR contains
-   [X] Feature

What is the purpose of this PR?
It will be possible to define data sources with `isList` flag set to false. This PR updates the types accordingly.
Relevant changes
Type generation will updates types based on `isList` flag

