### PR TITLE
[MOO-2069] Generate EditableImageValue for native images with allowUpload set to true

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added support for the `allowUpload` attribute on image properties in native widgets, generating `EditableImageValue<NativeImage>` when enabled.
+
 ### Changed
 
 -   We changed the order of imports in generated widget prop types to match that of the eslint sort-imports rule.

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
--   We added support for the `allowUpload` attribute on image properties in native widgets, generating `EditableImageValue<NativeImage>` when enabled.
+-   We added support for the `allowUpload` attribute on image properties in native widgets, generating `EditableImageValue<NativeImage>` when enabled, introduced in Mendix 11.11.
 
 ### Changed
 

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/pluggable-widgets-tools",
-  "version": "11.8.2",
+  "version": "11.11.0",
   "description": "Mendix Pluggable Widgets Tools",
   "engines": {
     "node": ">=20"

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/image.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/outputs/image.ts
@@ -32,7 +32,7 @@ export const imageNativeOutput = `export interface MyWidgetProps<Style> {
     style: Style[];
     image: DynamicValue<NativeImage>;
     image2?: DynamicValue<NativeImage>;
-    image3: DynamicValue<NativeImage>;
+    image3: EditableImageValue<NativeImage>;
     description: EditableValue<string>;
     action?: ActionValue;
 }`;

--- a/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -131,7 +131,10 @@ function toClientPropType(
         case "icon":
             return isNative ? "DynamicValue<NativeIcon>" : "DynamicValue<WebIcon>";
         case "image":
-            return isNative ? "DynamicValue<NativeImage>" : prop.$.allowUpload === "true" ? "EditableImageValue<WebImage>" : "DynamicValue<WebImage>";
+            if (prop.$.allowUpload === "true") {
+                return isNative ? "EditableImageValue<NativeImage>" : "EditableImageValue<WebImage>";
+            }
+            return isNative ? "DynamicValue<NativeImage>" : "DynamicValue<WebImage>";
         case "file":
             return prop.$.allowUpload ? "EditableFileValue" : "DynamicValue<FileValue>";
         case "datasource":

--- a/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generateClientTypes.ts
@@ -131,10 +131,8 @@ function toClientPropType(
         case "icon":
             return isNative ? "DynamicValue<NativeIcon>" : "DynamicValue<WebIcon>";
         case "image":
-            if (prop.$.allowUpload === "true") {
-                return isNative ? "EditableImageValue<NativeImage>" : "EditableImageValue<WebImage>";
-            }
-            return isNative ? "DynamicValue<NativeImage>" : "DynamicValue<WebImage>";
+            const imageType = isNative ? "NativeImage" : "WebImage";
+            return `${prop.$.allowUpload === "true" ? "EditableImageValue" : "DynamicValue"}<${imageType}>`;
         case "file":
             return prop.$.allowUpload ? "EditableFileValue" : "DynamicValue<FileValue>";
         case "datasource":


### PR DESCRIPTION
## Checklist

-   Contains unit tests ✅ 
-   Contains breaking changes ❌
-   Compatible with: MX 11
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [ ] Bug fix
-   [x] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [ ] Other (describe)

## What is the purpose of this PR?

We have integrated allowUpload property for image type for our use case in native signature widget and set its value to true. For it we will have to change the type for it to "EditableImageValue<NativeImage>" .  Updated the existing test's output accordingly.