### PR TITLE
Silence Sass legacy JS API deprecation warning

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 -   We changed the order of imports in generated widget prop types to match that of the eslint sort-imports rule.
+-   We silenced the Sass legacy JS API deprecation warning that appeared during widget bundling.
 
 ## [11.8.1] - 2026-03-16
 

--- a/packages/pluggable-widgets-tools/configs/rollup.config.mjs
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.mjs
@@ -158,7 +158,11 @@ export default async args => {
                     minimize: production,
                     plugins: [postcssImport(), postcssUrl({ url: "inline" })],
                     sourceMap: !production ? "inline" : false,
-                    use: ["sass"]
+                    use: {
+                        sass: {
+                            silenceDeprecations: ['legacy-js-api']
+                        }
+                    }
                 }),
                 ...getCommonPlugins({
                     sourceMaps: !production,
@@ -354,7 +358,11 @@ export function postCssPlugin(outputFormat, production, postcssPlugins = []) {
             ...postcssPlugins
         ],
         sourceMap: !production ? "inline" : false,
-        use: ["sass"],
+        use: {
+            sass: {
+                silenceDeprecations: ['legacy-js-api']
+            }
+        },
         to: join(outDir, `${outWidgetFile}.css`)
     });
 }


### PR DESCRIPTION
## Summary

- Suppress the "The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0" warning by configuring rollup-plugin-postcss to silence the `legacy-js-api` deprecation

## Changes

Updated `rollup.config.mjs` to pass `silenceDeprecations: ['legacy-js-api']` to the sass preprocessor in two places:
1. In the preview entry postcss plugin configuration (line 161)
2. In the `postCssPlugin` function (line 361)

This change ports the fix from https://github.com/mendix/web-widgets/pull/2234 to the widgets-tools repository.

## Test plan

- [ ] Build passes without sass deprecation warnings
- [ ] Widget builds work correctly with the updated configuration