### PR TITLE
Fix/windows mpk xml

### DIFF
--- a/packages/command-tests/commands.js
+++ b/packages/command-tests/commands.js
@@ -228,6 +228,7 @@ async function main() {
             ) {
                 throw new Error("Expected mpk file to be generated, but it wasn't.");
             }
+            checkWidgetBundleFiles();
         }
 
         async function testRelease() {
@@ -243,6 +244,18 @@ async function main() {
                 )
             ) {
                 throw new Error("Expected mpk file to be generated, but it wasn't.");
+            }
+            checkWidgetBundleFiles();
+        }
+
+        function checkWidgetBundleFiles() {
+            // XML files copied into the staging dir before zipping; missing here means a broken mpk.
+            const stagingDir = join(workDir, "dist", "tmp", "widgets");
+            const missing = ["package.xml", `${widgetPackageJson.widgetName}.xml`].filter(
+                f => !existsSync(join(stagingDir, f))
+            );
+            if (missing.length) {
+                throw new Error(`Expected widget bundle files in mpk, but missing: ${missing.join(", ")}.`);
             }
         }
 

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+-   We fixed an issue on Windows where the generated `.mpk` was missing the widget's `.xml` files and icon/tile PNGs.
+
 ### Changed
 
 -   We replaced `ts-jest` with `@swc/jest` as the Jest transform (3–5× faster for TSX-heavy test suites) and switched the test runner from `jest-jasmine2` to `jest-circus`.

--- a/packages/pluggable-widgets-tools/configs/rollup.config.mjs
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.mjs
@@ -320,9 +320,10 @@ export default async args => {
             clear({ targets: [outDir, mpkDir] }),
             command([
                 () => {
-                    cp(join(sourcePath, "src/**/*.xml"), outDir);
+                    // Re-target join(widgetRoot,...) after PR #182.
+                    cp("src/**/*.xml", outDir);
                     if (existsSync(`src/${widgetName}.icon.png`) || existsSync(`src/${widgetName}.tile.png`)) {
-                        cp(join(sourcePath, `src/${widgetName}.@(tile|icon)?(.dark).png`), outDir);
+                        cp(`src/${widgetName}.@(tile|icon)?(.dark).png`, outDir);
                     }
                 }
             ]),

--- a/packages/pluggable-widgets-tools/configs/rollup.config.native.mjs
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.native.mjs
@@ -257,9 +257,10 @@ export default async args => {
             clear({ targets: [outDir, mpkDir] }),
             command([
                 () => {
-                    cp(join(sourcePath, "src/**/*.xml"), outDir);
+                    // Re-target join(widgetRoot,...) after PR #182.
+                    cp("src/**/*.xml", outDir);
                     if (existsSync(`src/${widgetName}.icon.png`) || existsSync(`src/${widgetName}.tile.png`)) {
-                        cp(join(sourcePath, `src/${widgetName}.@(tile|icon)?(.dark).png`), outDir);
+                        cp(`src/${widgetName}.@(tile|icon)?(.dark).png`, outDir);
                     }
                 }
             ])


### PR DESCRIPTION
## Checklist

- Contains unit tests ✅
- Contains breaking changes ❌
- Compatible with: MX 9️⃣ (11.x)
- Did you update version and changelog? ✅ changelog / ❌ version
- PR title properly formatted? ✅

## This PR contains

-   [ ] Bug fix


## What is the purpose of this PR?

Fix Windows builds producing an .mpk missing the widget's .xml files and icon/tile PNGs.

_..._

## Relevant changes

The copy step used absolute drive-letter globs that fast-glob returns empty for on Windows, so the widget files were silently skipped; switched both rollup configs to relative globs and added an assertion in command-tests so an incomplete .mpk

## What should be covered while testing?

Build on Windows and Linux; confirm the .mpk contains package.xml and <Widget>.xml (and PNGs when present in src).

_..._


