### PR TITLE
[WTF-2710]: Fix unit tests failing on ValueStatus import

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+-   We added a built-in Jest mock for the `mendix` module, so widgets that import runtime values from it (e.g. `ValueStatus`, `FormatterType`) in unit tests no longer fail with "This package should not be used in the runtime".
+
 ## [11.12.0] - 2026-06-30
 
 ### Changed

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
--   We added a built-in Jest mock for the `mendix` module, so widgets that import runtime values from it (e.g. `ValueStatus`, `FormatterType`) in unit tests no longer fail with "This package should not be used in the runtime".
+-   We fixed an issue with the Jest configuration affecting unit tests for widgets importing enums from the mendix package (e.g. ValueStatus, FormatterType). It would cause tests to fail with the error "This package should not be used in the runtime".
 
 ## [11.12.0] - 2026-06-30
 

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "prepack": "shx rm -rf dist && tsc",
     "typecheck:test-config": "tsc -p test-config/tsconfig.json",
-    "test": "tsc -p test-config/tsconfig.json && jest"
+    "test": "pnpm typecheck:test-config && jest"
   },
   "files": [
     "bin",

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -12,7 +12,8 @@
   },
   "scripts": {
     "prepack": "shx rm -rf dist && tsc",
-    "test": "jest"
+    "typecheck:test-config": "tsc -p test-config/tsconfig.json",
+    "test": "tsc -p test-config/tsconfig.json && jest"
   },
   "files": [
     "bin",

--- a/packages/pluggable-widgets-tools/test-config/__mocks__/mendix.js
+++ b/packages/pluggable-widgets-tools/test-config/__mocks__/mendix.js
@@ -1,15 +1,26 @@
-// Runtime mock for the types-only `mendix` package, whose real entry throws
-// ("This package should not be used in the runtime"). `@swc/jest` can't inline
-// the ambient `const enum ValueStatus`, so it emits a live `require("mendix")`
-// that needs this safe module exporting the enum values widget code uses.
-//
-// Keep values in sync with node_modules/mendix/index.d.ts.
+// @ts-check
+// Runtime mock for the types-only `mendix` package (its real entry throws).
+// Stays plain JS because it ships inside the consumer's node_modules, where
+// jest won't transform TypeScript. The JSDoc `@type` annotations check the
+// values against `mendix`'s types (repo-only, via test-config/tsconfig.json)
+// and are erased at runtime.
+
+/** @typedef {typeof import("mendix")} MendixModule */
+
+/**
+ * Map an enum's type to `{ [Member]: itsStringValue }`.
+ * @template E
+ * @typedef {{ [K in keyof E]: `${Extract<E[K], string>}` }} EnumMock
+ */
+
 module.exports = {
+    /** @type {EnumMock<MendixModule["ValueStatus"]>} */
     ValueStatus: {
         Available: "available",
         Unavailable: "unavailable",
         Loading: "loading"
     },
+    /** @type {EnumMock<MendixModule["FormatterType"]>} */
     FormatterType: {
         Number: "number",
         DateTime: "datetime"

--- a/packages/pluggable-widgets-tools/test-config/__mocks__/mendix.js
+++ b/packages/pluggable-widgets-tools/test-config/__mocks__/mendix.js
@@ -1,0 +1,17 @@
+// Runtime mock for the types-only `mendix` package, whose real entry throws
+// ("This package should not be used in the runtime"). `@swc/jest` can't inline
+// the ambient `const enum ValueStatus`, so it emits a live `require("mendix")`
+// that needs this safe module exporting the enum values widget code uses.
+//
+// Keep values in sync with node_modules/mendix/index.d.ts.
+module.exports = {
+    ValueStatus: {
+        Available: "available",
+        Unavailable: "unavailable",
+        Loading: "loading"
+    },
+    FormatterType: {
+        Number: "number",
+        DateTime: "datetime"
+    }
+};

--- a/packages/pluggable-widgets-tools/test-config/jest.config.js
+++ b/packages/pluggable-widgets-tools/test-config/jest.config.js
@@ -24,6 +24,7 @@ module.exports = {
     },
     moduleNameMapper: {
         "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+        "^mendix$": join(__dirname, "__mocks__/mendix"),
         "mendix/components/web/Icon": join(__dirname, "__mocks__/WebIcon"),
         "mendix/filters/builders": join(__dirname, "__mocks__/FilterBuilders"),
         "\\.png$": join(__dirname, "assetsTransformer.js"),

--- a/packages/pluggable-widgets-tools/test-config/test-index.js
+++ b/packages/pluggable-widgets-tools/test-config/test-index.js
@@ -1,6 +1,21 @@
 require("@testing-library/jest-dom");
 const { TextEncoder, TextDecoder } = require("util");
 
+// `@swc/jest` can't inline mendix's ambient `const enum`s, so it emits a real
+// `require("mendix")`. Mock the runtime values.
+// Keep in sync with node_modules/mendix/index.d.ts.
+jest.mock("mendix", () => ({
+    ValueStatus: {
+        Available: "available",
+        Unavailable: "unavailable",
+        Loading: "loading"
+    },
+    FormatterType: {
+        Number: "number",
+        DateTime: "datetime"
+    }
+}));
+
 Object.defineProperties(global, {
     TextEncoder: {
         value: TextEncoder

--- a/packages/pluggable-widgets-tools/test-config/test-index.js
+++ b/packages/pluggable-widgets-tools/test-config/test-index.js
@@ -1,21 +1,6 @@
 require("@testing-library/jest-dom");
 const { TextEncoder, TextDecoder } = require("util");
 
-// `@swc/jest` can't inline mendix's ambient `const enum`s, so it emits a real
-// `require("mendix")`. Mock the runtime values.
-// Keep in sync with node_modules/mendix/index.d.ts.
-jest.mock("mendix", () => ({
-    ValueStatus: {
-        Available: "available",
-        Unavailable: "unavailable",
-        Loading: "loading"
-    },
-    FormatterType: {
-        Number: "number",
-        DateTime: "datetime"
-    }
-}));
-
 Object.defineProperties(global, {
     TextEncoder: {
         value: TextEncoder

--- a/packages/pluggable-widgets-tools/test-config/tsconfig.json
+++ b/packages/pluggable-widgets-tools/test-config/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../configs/tsconfig.base",
+    "compilerOptions": {
+        "noEmit": true,
+        "allowJs": true,
+        "checkJs": true,
+        "moduleResolution": "bundler"
+    },
+    "include": ["__mocks__/mendix.js"]
+}


### PR DESCRIPTION
## Checklist

-   Contains unit tests  ❌
-   Contains breaking changes  ❌
-   Did you update version and changelog?  ❌


## This PR contains

-   [ ] Bug fix


## What is the purpose of this PR?

_..._

## Relevant changes

Unit tests run via pluggable-widgets-tools test:unit:web fail to load any test suite whose module graph imports a runtime value from the mendix package. 
The suite errors out before any test runs with "This package should not be used in the runtime."
