### PR TITLE
[WTF-2688]: Backport fix vulnerabilities in transitive dependencies of PWT

### DIFF
--- a/packages/command-tests/commands.js
+++ b/packages/command-tests/commands.js
@@ -193,9 +193,6 @@ async function main() {
             widgetPackageJson = await readJson(join(workDir, "package.json"));
             widgetPackageJson.devDependencies["@mendix/pluggable-widgets-tools"] = toolsPackagePath;
 
-            // Adds compatibility to new React 18 and React native 0.72
-            fixPackageJson(widgetPackageJson);
-
             await writeJson(join(workDir, "package.json"), widgetPackageJson);
 
             await execAsync("npm install --loglevel=error", workDir, logger);
@@ -400,24 +397,3 @@ async function execFailedAsync(command, workDir) {
     throw new Error(`Expected '${command}' to fail, but it didn't!`);
 }
 
-function fixPackageJson(json) {
-    const devDependencies = {
-        "@types/jest": "^29.0.0",
-        "@types/react": "^19.0.0",
-        "@types/react-native": "0.78.2",
-        "@types/react-dom": "^19.0.0",
-        "@types/react-test-renderer": "~18.0.0"
-    };
-    const overrides = {
-        react: "^19.0.0",
-        "react-dom": "^19.0.0",
-        "react-native": "0.78.2"
-    };
-
-    Object.keys(devDependencies)
-        .filter(dep => !!json.devDependencies[dep])
-        .forEach(dep => (json.devDependencies[dep] = devDependencies[dep]));
-
-    json.overrides = overrides;
-    json.resolutions = overrides;
-}

--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -10,23 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We cleaned up a template with unused imports.
 
-## [11.11.0] - 2026-06-04
-
-### Changed
-
 -   We updated the version of cypress when e2e tests are generated.
 
 -   We renamed the initial e2e tests so they match cypress' default specPattern.
-
-## [11.6.0] - 2026-03-04
-
-### Changed
-
--   We upgraded React to version 19 and React Native to version 0.78.2 for generated widgets.
-
-## [11.3.1] - 2026-02-04
-
-### Changed
 
 -   We migrated the generated unit tests to use React Testing Library instead of enzyme.
 

--- a/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },<% } %>
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.24.1"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasUnitTests) { %>,
     "@types/jest": "^30.0.0"<% } %><% } %>
   },
@@ -35,17 +35,17 @@
 
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",<% if (isLanguageTS) { %>
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",<% } %>
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",<% } %>
+    "react-native": "~0.77.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",<% if (isLanguageTS) { %>
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",<% } %>
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",<% } %>
+    "react-native": "~0.77.3"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.24.1"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasE2eTests) { %>,
     "@types/jasmine": "^3.6.9"<% } %><% if (hasUnitTests) { %>,
     "@types/jest": "^30.0.0"<% } %><% } %><% if (hasE2eTests) { %>,
@@ -38,15 +38,15 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"<% if (isLanguageTS) { %>,
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"<% } %>
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"<% if (isLanguageTS) { %>,
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"<% } %>
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"<% if (isLanguageTS) { %>,
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"<% } %>
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"<% if (isLanguageTS) { %>,
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"<% } %>
   }
 }

--- a/packages/generator-widget/package.json
+++ b/packages/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "11.11.0",
+  "version": "10.24.1",
   "description": "Mendix Pluggable Widgets Generator",
   "type": "module",
   "engines": {

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -109,7 +109,9 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^16.18.126",
-    "@types/xml2js": "^0.4.5",
+    "@types/xml2js": "^0.4.5"
+  },
+  "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "~0.77.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,15 @@ importers:
       prettier:
         specifier: ^2.5.1
         version: 2.8.8
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      react-native:
+        specifier: ~0.77.3
+        version: 0.77.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.31)(react@18.3.1)
       react-test-renderer:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -382,15 +391,6 @@ importers:
       '@types/xml2js':
         specifier: ^0.4.5
         version: 0.4.14
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-      react-native:
-        specifier: ~0.77.3
-        version: 0.77.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.31)(react@18.3.1)
 
   packages/release-tools:
     dependencies:


### PR DESCRIPTION
## Checklist

-   Contains unit tests ❌
-   Contains breaking changes ✅ 
-   Compatible with: 10.24
-   Did you update version and changelog? ✅ 
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   Backport of several features and bugfixes

## What is the purpose of this PR?

Provide an official version of PWT aligned with LTS versioning.

## Relevant changes

- Fork of master, where React 19 support was reverted.
- To fix dependency resolution issues React is now marked as a peer dependency

## What should be covered while testing?

- Widgets built with this version of PWT work in 10.24 and up.
