### PR TITLE
[WTF-2688]: Fix command tests (version/10.24)

### DIFF
--- a/packages/command-tests/commands.js
+++ b/packages/command-tests/commands.js
@@ -193,9 +193,6 @@ async function main() {
             widgetPackageJson = await readJson(join(workDir, "package.json"));
             widgetPackageJson.devDependencies["@mendix/pluggable-widgets-tools"] = toolsPackagePath;
 
-            // Adds compatibility to new React 18 and React native 0.72
-            fixPackageJson(widgetPackageJson);
-
             await writeJson(join(workDir, "package.json"), widgetPackageJson);
 
             await execAsync("npm install --loglevel=error", workDir, logger);
@@ -398,26 +395,4 @@ async function execFailedAsync(command, workDir) {
         return;
     }
     throw new Error(`Expected '${command}' to fail, but it didn't!`);
-}
-
-function fixPackageJson(json) {
-    const devDependencies = {
-        "@types/jest": "^29.0.0",
-        "@types/react": "^19.0.0",
-        "@types/react-native": "0.78.2",
-        "@types/react-dom": "^19.0.0",
-        "@types/react-test-renderer": "~18.0.0"
-    };
-    const overrides = {
-        react: "^19.0.0",
-        "react-dom": "^19.0.0",
-        "react-native": "0.78.2"
-    };
-
-    Object.keys(devDependencies)
-        .filter(dep => !!json.devDependencies[dep])
-        .forEach(dep => (json.devDependencies[dep] = devDependencies[dep]));
-
-    json.overrides = overrides;
-    json.resolutions = overrides;
 }

--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -10,23 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We cleaned up a template with unused imports.
 
-## [11.11.0] - 2026-06-04
-
-### Changed
-
 -   We updated the version of cypress when e2e tests are generated.
 
 -   We renamed the initial e2e tests so they match cypress' default specPattern.
-
-## [11.6.0] - 2026-03-04
-
-### Changed
-
--   We upgraded React to version 19 and React Native to version 0.78.2 for generated widgets.
-
-## [11.3.1] - 2026-02-04
-
-### Changed
 
 -   We migrated the generated unit tests to use React Testing Library instead of enzyme.
 

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js-unit.json
@@ -27,19 +27,19 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"
+    "@mendix/pluggable-widgets-tools": "^10.24.1"
   },
   "dependencies": {
 
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-js.json
@@ -22,19 +22,19 @@
     "release": "pluggable-widgets-tools release:native"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"
+    "@mendix/pluggable-widgets-tools": "^10.24.1"
   },
   "dependencies": {
 
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts-unit.json
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "@types/big.js": "^6.0.2",
     "@types/jest": "^30.0.0"
   },
@@ -35,17 +35,17 @@
 
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_native.json-ts.json
@@ -22,24 +22,24 @@
     "release": "pluggable-widgets-tools release:native"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "@types/big.js": "^6.0.2"
   },
   "dependencies": {
 
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "react-native": "~0.77.3"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-e2e.json
@@ -26,18 +26,18 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "cypress": "^15.15.0"
   },
   "dependencies": {
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit-e2e.json
@@ -28,18 +28,18 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "cypress": "^15.15.0"
   },
   "dependencies": {
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js-unit.json
@@ -27,17 +27,17 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"
+    "@mendix/pluggable-widgets-tools": "^10.24.1"
   },
   "dependencies": {
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-js.json
@@ -25,17 +25,17 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"
+    "@mendix/pluggable-widgets-tools": "^10.24.1"
   },
   "dependencies": {
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-e2e.json
@@ -26,7 +26,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "@types/big.js": "^6.0.2",
     "@types/jasmine": "^3.6.9",
     "cypress": "^15.15.0"
@@ -35,15 +35,15 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit-e2e.json
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "@types/big.js": "^6.0.2",
     "@types/jasmine": "^3.6.9",
     "@types/jest": "^30.0.0",
@@ -38,15 +38,15 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts-unit.json
@@ -27,7 +27,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "@types/big.js": "^6.0.2",
     "@types/jest": "^30.0.0"
   },
@@ -35,15 +35,15 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
+++ b/packages/generator-widget/generators/app/templates/packages/__tests__/outputs/package_web.json-ts.json
@@ -25,22 +25,22 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0",
+    "@mendix/pluggable-widgets-tools": "^10.24.1",
     "@types/big.js": "^6.0.2"
   },
   "dependencies": {
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_native.json.ejs
@@ -27,7 +27,7 @@
     "output": "./dist/testresults/TESTS-Jest.xml"
   },<% } %>
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.24.1"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasUnitTests) { %>,
     "@types/jest": "^30.0.0"<% } %><% } %>
   },
@@ -35,17 +35,17 @@
 
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",<% if (isLanguageTS) { %>
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",<% } %>
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",<% } %>
+    "react-native": "~0.77.3"
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",<% if (isLanguageTS) { %>
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",<% } %>
-    "react-native": "~0.78.2"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",<% if (isLanguageTS) { %>
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",<% } %>
+    "react-native": "~0.77.3"
   }
 }

--- a/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
+++ b/packages/generator-widget/generators/app/templates/packages/package_web.json.ejs
@@ -28,7 +28,7 @@
     "release": "pluggable-widgets-tools release:web"
   },
   "devDependencies": {
-    "@mendix/pluggable-widgets-tools": "^11.11.0"<% if (isLanguageTS) { %>,
+    "@mendix/pluggable-widgets-tools": "^10.24.1"<% if (isLanguageTS) { %>,
     "@types/big.js": "^6.0.2"<% if (hasE2eTests) { %>,
     "@types/jasmine": "^3.6.9"<% } %><% if (hasUnitTests) { %>,
     "@types/jest": "^30.0.0"<% } %><% } %><% if (hasE2eTests) { %>,
@@ -38,15 +38,15 @@
     "classnames": "^2.5.1"
   },
   "resolutions": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"<% if (isLanguageTS) { %>,
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"<% } %>
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"<% if (isLanguageTS) { %>,
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"<% } %>
   },
   "overrides": {
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"<% if (isLanguageTS) { %>,
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"<% } %>
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"<% if (isLanguageTS) { %>,
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"<% } %>
   }
 }

--- a/packages/generator-widget/package.json
+++ b/packages/generator-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mendix/generator-widget",
-  "version": "11.11.0",
+  "version": "10.24.1",
   "description": "Mendix Pluggable Widgets Generator",
   "type": "module",
   "engines": {

--- a/packages/pluggable-widgets-tools/package.json
+++ b/packages/pluggable-widgets-tools/package.json
@@ -109,7 +109,9 @@
   "devDependencies": {
     "@types/jest": "^30.0.0",
     "@types/node": "^16.18.126",
-    "@types/xml2js": "^0.4.5",
+    "@types/xml2js": "^0.4.5"
+  },
+  "peerDependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "~0.77.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,15 @@ importers:
       prettier:
         specifier: ^2.5.1
         version: 2.8.8
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      react-native:
+        specifier: ~0.77.3
+        version: 0.77.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.31)(react@18.3.1)
       react-test-renderer:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
@@ -382,15 +391,6 @@ importers:
       '@types/xml2js':
         specifier: ^0.4.5
         version: 0.4.14
-      react:
-        specifier: ^18.2.0
-        version: 18.3.1
-      react-dom:
-        specifier: ^18.2.0
-        version: 18.3.1(react@18.3.1)
-      react-native:
-        specifier: ~0.77.3
-        version: 0.77.3(@babel/core@7.29.0)(@babel/preset-env@7.29.5(@babel/core@7.29.0))(@types/react@18.3.31)(react@18.3.1)
 
   packages/release-tools:
     dependencies:


### PR DESCRIPTION
This PR makes changes necessary to allow the pipelines for version/10.24 to succeed.

### Changes

- Update generator to generate appropriate dependency versions
- Set react, react-dom, and react-native as peer dependencies (to fix @testing-library/react being installed as nested dependency)
- Update command tests to work with react 18