### PR TITLE
fix: use correct public path for assets in React (ESM) builds

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 -   We increased the minimum node version to 22.
 
+### Fixed
+
+-   We fixed an issue where images imported in widgets were not displayed correctly in the React client when deployed in the cloud.
+
 ## [11.12.0] - 2026-06-30
 
 ### Changed

--- a/packages/pluggable-widgets-tools/configs/rollup.config.mjs
+++ b/packages/pluggable-widgets-tools/configs/rollup.config.mjs
@@ -105,7 +105,11 @@ export default async args => {
                 url({
                     include: imagesAndFonts,
                     limit: 0,
-                    publicPath: `${join("widgets", outAssetsDir)}/`, // Prefix for the actual import, relative to Mendix web server root
+                    // Prefix for the actual import, relative to Mendix web server root
+                    // dojo uses: "widgets/<widget-path>/assets/123abc.png"
+                    // react uses:   "dist/<widget-path>/assets/123abc.png"
+                    publicPath:
+                        outputFormat === "es" ? `${join("dist", outAssetsDir)}/` : `${join("widgets", outAssetsDir)}/`,
                     destDir: absoluteOutAssetsDir
                 }),
                 postCssPlugin(outputFormat, production),


### PR DESCRIPTION
## Summary

- Fixes images imported in widgets not being displayed correctly in the React client when deployed in the cloud.
- The ESM (React) bundle now resolves assets under `dist/<widget-path>/assets/`, while the AMD (Dojo) bundle continues to use `widgets/<widget-path>/assets/`.

## Test plan

- [ ] Build a widget that imports an image asset
- [ ] Verify the image loads correctly in the React client (cloud deployment)
- [ ] Verify the image still loads correctly in the Dojo client