### PR TITLE
Determine release tag based on current latest

### DIFF
--- a/.github/workflows/PublishNpm.yml
+++ b/.github/workflows/PublishNpm.yml
@@ -73,6 +73,21 @@ jobs:
         with:
           node-version: '24' # Includes a version of npm higher than 11.5.1, which is needed for OIDC
 
+      - name: Release Tag
+        id: tag
+        run: |
+          release="${{ matrix.release.version }}"
+          latest="$(npm view @mendix/${{ matrix.release.package }} dist-tags.latest)"
+          older="$(npx semver@7.8.5 "$latest" "$release" 2>/dev/null | head -n 1)"
+          tag="latest"
+          if [[ "$latest" != "$older" ]]; then
+            tag="$(echo "$release" | sed -E 's/^([0-9]+\.[0-9]+).[0-9]+$/\1-latest/')"
+          fi
+          printf 'RELEASE_TAG=%s' "$tag" >> "$GITHUB_OUTPUT"
+
+
       - name: Publish package
         working-directory: ./packages/${{ matrix.release.package }}
-        run: npm publish mendix-${{ matrix.release.package }}-${{matrix.release.version }}.tgz
+        run: npm publish --tag ${{ vars.tag }} mendix-${{ matrix.release.package }}-${{matrix.release.version }}.tgz
+        variables:
+          tag: ${{ steps.tag.outputs.RELEASE_TAG }}

--- a/.github/workflows/ShaCheck.yml
+++ b/.github/workflows/ShaCheck.yml
@@ -2,9 +2,13 @@ name: Ensure SHA pinned actions
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - version/*
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - version/*
 
 jobs:
   harden_security:

--- a/.github/workflows/TestAndBuild.yml
+++ b/.github/workflows/TestAndBuild.yml
@@ -2,13 +2,17 @@ name: Test & Build
 
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+      - version/*
     paths:
       - 'pnpm-lock.yaml'
       - 'packages/**'
       - '.github/workflows/TestAndBuild.yml'
   pull_request:
-    branches: [master]
+    branches:
+      - master
+      - version/*
     paths:
       - 'pnpm-lock.yaml'
       - 'packages/**'

--- a/.github/workflows/TestPWTCommands.yml
+++ b/.github/workflows/TestPWTCommands.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - version/*
     paths:
       - 'pnpm-lock.yaml'
       - 'packages/generator-widget/**'
@@ -12,6 +13,7 @@ on:
   pull_request:
     branches:
       - master
+      - version/*
     paths:
       - 'pnpm-lock.yaml'
       - 'packages/generator-widget/**'


### PR DESCRIPTION
Updates the publish workflow to automatically create a latest tag for the release.

Releases with versions greater than the current latest on npm will receive `latest`. Other releases will receive the tag `<major>.<minor>-latest`.

- [ ] Backport to `version/10.24`
- [ ] Backport to `version/11.12`