### PR TITLE
Revert "Update changelog for pluggable-widgets-tools" (version/10.24)

### DIFF
--- a/packages/generator-widget/CHANGELOG.md
+++ b/packages/generator-widget/CHANGELOG.md
@@ -6,12 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [10.24.1] - 2026-08-04
-
 ### Changed
 
 -   We cleaned up a template with unused imports.
-
 -   We increased the minimum node version to 22.
 
 -   We updated the version of cypress when e2e tests are generated.

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [10.24.1] - 2026-08-06
-
 ### Added
 
 -   We fixed an issue with the Jest configuration affecting unit tests for widgets importing enums from the mendix package (e.g. ValueStatus, FormatterType). It would cause tests to fail with the error "This package should not be used in the runtime".


### PR DESCRIPTION
To rerun the release workflow we need to revert the changelog update.