### PR TITLE
[WTF-2714] Allow PW to refer to all system texts

### DIFF
--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 -   We increased the minimum node version to 22.
+-   We changed [System Text XML](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#text) type to use `namespace` instead of `widgetId`, since now we allow plugable widgets to refer to all system texts.
 
 ### Fixed
 

--- a/packages/pluggable-widgets-tools/CHANGELOG.md
+++ b/packages/pluggable-widgets-tools/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 -   We increased the minimum node version to 22.
--   We changed [System Text XML](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#text) type to use `namespace` instead of `widgetId`, since now we allow plugable widgets to refer to all system texts.
+-   We changed [System Text XML](https://docs.mendix.com/apidocs-mxsdk/apidocs/pluggable-widgets-property-types/#text) type to use `namespace` instead of `widgetId`, since we now allow Pluggable Widgets to refer to all system texts.
 
 ### Fixed
 

--- a/packages/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/WidgetXml.ts
@@ -145,7 +145,7 @@ export interface SystemTextParameter {
 
 export interface ExternalSystemTextNamespace {
     $: {
-        widgetId: string;
+        namespace: string;
     };
     text: ExternalSystemText[];
 }

--- a/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/systemtexts.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/__tests__/inputs/systemtexts.ts
@@ -16,11 +16,11 @@ const systemProperty = `<systemProperty key="Text">
             <parameter caption="Count" />
         </parameters>
     </text>
-    <externalTexts widgetId="mendix.textbox.TextBox">
+    <externalTexts namespace="mendix.textbox.TextBox">
         <text key="label" />
         <text key="placeholder" />
     </externalTexts>
-    <externalTexts widgetId="mendix.datagrid.DataGrid" />
+    <externalTexts namespace="mendix.datagrid.DataGrid" />
 </systemProperty>`;
 
 export const systemTextsInput = `<?xml version="1.0" encoding="utf-8"?>

--- a/packages/pluggable-widgets-tools/src/typings-generator/generateSystemTexts.ts
+++ b/packages/pluggable-widgets-tools/src/typings-generator/generateSystemTexts.ts
@@ -4,7 +4,7 @@ import { SystemProperty, TextSystemProperty } from "./WidgetXml";
 
 const STAR = "*" as const;
 type Star = typeof STAR;
-type Text = { key: string; parameters: string[] } | { widgetId: string; key: Star | string[] };
+type Text = { key: string; parameters: string[] } | { namespace: string; key: Star | string[] };
 
 function textsFromSystemProperty(node: SystemProperty): Text[] {
     if (!isTextSystemProperty(node)) return [];
@@ -16,7 +16,7 @@ function textsFromSystemProperty(node: SystemProperty): Text[] {
         })),
         ...(node.externalTexts ?? []).map(e => {
             return {
-                widgetId: e.$.widgetId,
+                namespace: e.$.namespace,
                 key: e.text === undefined ? STAR : e.text.map(t => t.$.key)
             };
         })
@@ -28,11 +28,11 @@ function isTextSystemProperty(node: SystemProperty): node is TextSystemProperty 
 }
 
 function generateTextType(t: Text): string {
-    if ("widgetId" in t) {
+    if ("namespace" in t) {
         if (t.key === STAR) {
-            return `"${t.widgetId}": [key: string, params?: string[]]`;
+            return `"${t.namespace}": [key: string, params?: string[]]`;
         }
-        return `"${t.widgetId}": [key: ${t.key.map(key => `"${key}"`).join(" | ")}, params?: string[]]`;
+        return `"${t.namespace}": [key: ${t.key.map(key => `"${key}"`).join(" | ")}, params?: string[]]`;
     }
 
     const parameterTypes = t.parameters.map(p => `${normalizeParameterName(p)}: string`);


### PR DESCRIPTION
Rename `widgetId` to `namespace` to reflect SystemTexts ability to refer to all system texts
## Todo

-   Update mendix version to `11.15` after release

## Checklist

-   Contains unit tests ✅ ❌
-   Contains breaking changes ✅ ❌
-   Compatible with: MX 7️⃣, 8️⃣, 9️⃣
-   Did you update version and changelog? ✅ ❌
-   PR title properly formatted (`[XX-000]: description`)? ✅ 

## This PR contains

-   [ ] Bug fix
-   [ ] Feature
-   [ ] Refactor
-   [ ] Documentation
-   [x] Other: Rename of interface member

## What is the purpose of this PR?

Rename `widgetId` to `namespace` to reflect SystemTexts ability to refer to all system texts

## Relevant changes

Originally `widgetId` was used to reference the external widget texts. We now allow mapping to all system texts, this change was implemented to reflect the ability to all core system texts using namespaces. e.g. `mxui.common`

## What should be covered while testing?

Tests were updated to match new typings